### PR TITLE
Provena PR (Bug Fix): Fixing versions for pydantic and pytest-docker

### DIFF
--- a/admin-tooling/prov-exporter/requirements.txt
+++ b/admin-tooling/prov-exporter/requirements.txt
@@ -1,5 +1,5 @@
 requests
-pydantic
+pydantic==1.*
 typer[all]
 pytz
 

--- a/admin-tooling/prov-store/requirements.txt
+++ b/admin-tooling/prov-store/requirements.txt
@@ -1,5 +1,5 @@
 requests
-pydantic
+pydantic==1.*
 typer[all]
 
 # Shared interfaces

--- a/admin-tooling/registry/requirements.txt
+++ b/admin-tooling/registry/requirements.txt
@@ -2,7 +2,7 @@ requests
 python-jose
 mypy
 types-requests
-pydantic
+pydantic==1.*
 typer[all]
 
 # Shared interfaces

--- a/admin-tooling/search-cluster/requirements.txt
+++ b/admin-tooling/search-cluster/requirements.txt
@@ -2,7 +2,7 @@ requests
 python-jose
 mypy
 types-requests
-pydantic
+pydantic==1.*
 python-dotenv
 typer[all]
 

--- a/admin-tooling/tooling-environment-manager/setup.py
+++ b/admin-tooling/tooling-environment-manager/setup.py
@@ -11,7 +11,7 @@ setup(
         ]
     ),
     install_requires=[
-        'pydantic'
+        'pydantic==1.*'
     ],
     package_data={
         'ToolingEnvironmentManager': ['py.typed']

--- a/auth-api/docker-requirements.txt
+++ b/auth-api/docker-requirements.txt
@@ -7,7 +7,7 @@ setuptools
 boto3
 jsonschema
 mangum
-pydantic
+pydantic==1.*
 python-dotenv
 
 # Keycloak auth test package

--- a/auth-api/requirements.txt
+++ b/auth-api/requirements.txt
@@ -7,7 +7,7 @@ setuptools
 boto3
 jsonschema
 mangum
-pydantic
+pydantic==1.*
 python-dotenv
 
 # this links to the utilities package deployed as part of 

--- a/data-store-api/docker-requirements.txt
+++ b/data-store-api/docker-requirements.txt
@@ -8,7 +8,7 @@ jsonschema
 httpx
 mangum
 aws-secretsmanager-caching
-pydantic
+pydantic==1.*
 python-dotenv
 aiocache
 

--- a/data-store-api/requirements.txt
+++ b/data-store-api/requirements.txt
@@ -9,7 +9,7 @@ httpx
 mangum
 aws-secretsmanager-caching
 types-requests
-pydantic 
+pydantic==1.*
 python-dotenv
 aiocache
 

--- a/identity-service/base_requirements.txt
+++ b/identity-service/base_requirements.txt
@@ -4,8 +4,7 @@ requests
 python-jose
 setuptools
 mangum
-pydantic
-pydantic[email]
+pydantic[email]==1.*
 python-dotenv
 botocore
 boto3

--- a/identity-service/testing_requirements.txt
+++ b/identity-service/testing_requirements.txt
@@ -6,7 +6,6 @@ pytest
 # pytest plugins
 pytest-dotenv
 pytest-depends
-pytest-docker
 pytest-mock
 pytest-asyncio
 httpx

--- a/prov-api/docker-requirements.txt
+++ b/prov-api/docker-requirements.txt
@@ -9,11 +9,10 @@ jsonschema
 httpx
 mangum
 aws-secretsmanager-caching
-pydantic
+pydantic==1.*
 cachetools
 aiocache
 types-cachetools
-pydantic[email]
 prov
 # prov-db-connector (can't use original due to bug - this is forked version)
 git+https://github.com/gbrrestoration/prov-db-connector#egg=prov-db-connector

--- a/prov-api/requirements.txt
+++ b/prov-api/requirements.txt
@@ -9,8 +9,7 @@ httpx
 mangum
 aws-secretsmanager-caching
 types-requests
-pydantic
-pydantic[email]
+pydantic==1.*
 python-multipart
 aiocache
 cachetools

--- a/prov-api/testing_requirements.txt
+++ b/prov-api/testing_requirements.txt
@@ -9,7 +9,7 @@ pytest
 # pytest plugins
 pytest-dotenv
 pytest-depends
-pytest-docker
+pytest-docker==1.*
 pytest-mock
 pytest-asyncio
 

--- a/prov_job_dispatcher/base_requirements.txt
+++ b/prov_job_dispatcher/base_requirements.txt
@@ -1,5 +1,5 @@
 # normal requirements
-pydantic[email]
+pydantic[email]==1.*
 requests
 aws_secretsmanager_caching
 boto3

--- a/registry-api/docker-requirements.txt
+++ b/registry-api/docker-requirements.txt
@@ -8,8 +8,7 @@ jsonschema
 httpx
 mangum
 aws-secretsmanager-caching
-pydantic
-pydantic[email]
+pydantic[email]==1.*
 python-dotenv
 
 # requires GITHUB_TOKEN as environment variable 

--- a/registry-api/requirements.txt
+++ b/registry-api/requirements.txt
@@ -9,8 +9,7 @@ httpx
 mangum
 aws-secretsmanager-caching
 types-requests
-pydantic
-pydantic[email]
+pydantic[email]==1.*
 python-dotenv
 
 # this links to the utilities package deployed as part of 

--- a/scripts/interface_management/requirements.txt
+++ b/scripts/interface_management/requirements.txt
@@ -1,2 +1,2 @@
 pydantic-to-typescript
-pydantic[email]
+pydantic[email]==1.*

--- a/search-api/base_requirements.txt
+++ b/search-api/base_requirements.txt
@@ -4,8 +4,7 @@ requests
 python-jose
 setuptools
 mangum
-pydantic
-pydantic[email]
+pydantic[email]==1.*
 python-dotenv
 botocore
 boto3

--- a/search-api/testing_requirements.txt
+++ b/search-api/testing_requirements.txt
@@ -7,7 +7,6 @@ httpx
 # pytest plugins
 pytest-dotenv
 pytest-depends
-pytest-docker
 pytest-mock
 pytest-asyncio
 

--- a/search-utils/record-streamer-lambda/base_requirements.txt
+++ b/search-utils/record-streamer-lambda/base_requirements.txt
@@ -1,5 +1,5 @@
 # normal requirements
-pydantic[email]
+pydantic[email]==1.*
 requests
 boto3
 botocore

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -5,8 +5,7 @@ requests
 pytest-dotenv
 mypy
 types-requests
-pydantic[email]
-pydantic
+pydantic[email]==1.*
 
 
 # from utilities packages.

--- a/utilities/packages/python/fast-api-keycloak-auth/setup.py
+++ b/utilities/packages/python/fast-api-keycloak-auth/setup.py
@@ -4,7 +4,7 @@ setup(
     name='fast-api-keycloak-auth',
     version='0.1.0',
     packages=find_packages(include=['KeycloakFastAPI', 'KeyCloakFastAPI.*']),
-    install_requires=['fastapi', 'pydantic', 'requests', 'python-jose'],
+    install_requires=['fastapi', 'pydantic==1.*', 'requests', 'python-jose'],
     package_data = {
         'KeycloakFastAPI' : ['py.typed']
     }

--- a/utilities/packages/python/keycloak-utils/setup.py
+++ b/utilities/packages/python/keycloak-utils/setup.py
@@ -5,7 +5,7 @@ setup(
     version='0.1.0',
     packages=find_packages(
         include=['KeycloakRestUtilities', 'KeycloakRestUtilities.*']),
-    install_requires=['requests', 'types-requests', 'pydantic', 'python-jose'],
+    install_requires=['requests', 'types-requests', 'pydantic==1.*', 'python-jose'],
     package_data={
         'KeycloakRestUtilities': ['py.typed']
     }

--- a/utilities/packages/python/shared-interfaces/setup.py
+++ b/utilities/packages/python/shared-interfaces/setup.py
@@ -11,9 +11,8 @@ setup(
         ]
     ),
     install_requires=[
-        'pydantic',
         'fastapi',
-        'pydantic[email]',
+        'pydantic[email]==1.*',
         'email-validator'
     ],
     package_data={


### PR DESCRIPTION
# Provena PR (Bug Fix): Fixing versions for pydantic and pytest-docker

## Checklist

-   [x] If tests are required for this change, are they implemented?
-   [x] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [x] If migrations are required, is the process documented below?
-   [x] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [ ] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [x] If change requires update to the [manual testing runsheet](https://confluence.csiro.au/pages/viewpage.action?pageId=1701138616), is there a task to track it and/or is it completed?

## Description

Fixes the pytest-docker to v1.* and pydantic to v1.* - both of which recently had breaking changes in v2 bump. 
