### PR TITLE
Missing pydantic version pins

### DIFF
--- a/identity-service/base_requirements.txt
+++ b/identity-service/base_requirements.txt
@@ -4,7 +4,7 @@ requests
 python-jose
 setuptools
 mangum
-pydantic[email]==1.*
+pydantic[email]==1.10.12
 python-dotenv
 botocore
 boto3

--- a/registry-api/docker-requirements.txt
+++ b/registry-api/docker-requirements.txt
@@ -8,7 +8,7 @@ jsonschema
 httpx
 mangum
 aws-secretsmanager-caching
-pydantic[email]==1.*
+pydantic[email]==1.10.12
 python-dotenv
 shapely
 pyproj

--- a/registry-api/requirements.txt
+++ b/registry-api/requirements.txt
@@ -9,7 +9,7 @@ httpx
 mangum
 aws-secretsmanager-caching
 types-requests
-pydantic[email]==1.*
+pydantic[email]==1.10.12
 python-dotenv
 shapely
 pyproj

--- a/repo-tools/github-version/requirements.txt
+++ b/repo-tools/github-version/requirements.txt
@@ -1,3 +1,3 @@
 typer[all]
-pydantic[dotenv]==1.*
+pydantic[dotenv]==1.10.12
 PyGithub

--- a/scripts/interface_management/requirements.txt
+++ b/scripts/interface_management/requirements.txt
@@ -1,3 +1,3 @@
 pydantic-to-typescript
-pydantic[email]==1.*
+pydantic[email]==1.10.12
 isodate

--- a/search-api/base_requirements.txt
+++ b/search-api/base_requirements.txt
@@ -4,7 +4,7 @@ requests
 python-jose
 setuptools
 mangum
-pydantic[email]==1.*
+pydantic[email]==1.10.12
 python-dotenv
 botocore
 boto3

--- a/search-utils/record-streamer-lambda/base_requirements.txt
+++ b/search-utils/record-streamer-lambda/base_requirements.txt
@@ -1,5 +1,5 @@
 # normal requirements
-pydantic[email]==1.*
+pydantic[email]==1.10.12
 requests
 boto3
 botocore

--- a/tests/integration/requirements.txt
+++ b/tests/integration/requirements.txt
@@ -5,7 +5,7 @@ requests
 pytest-dotenv
 mypy
 types-requests
-pydantic[email]==1.*
+pydantic[email]==1.10.12
 networkx==3.*
 
 


### PR DESCRIPTION
# Provena PR (Bug Fix): Missed some pydantic v1.10.12 version pins in release 2.1.0

Replaces more missing pip requirement version pins for pydantic due to v1.10.13 dependency issues.