### PR TITLE
Provena PR (Bug Fix): Revert Metadata Reason Fix

### DIFF
--- a/data-store-api/routes/register/register.py
+++ b/data-store-api/routes/register/register.py
@@ -481,7 +481,7 @@ async def revert_metadata(
         domain_info=revised_domain_info,
         id=revert_request.id,
         secret_cache=secret_cache,
-        reason=f"Reverting dataset to history id {revert_request.history_id}.",
+        reason=f"Reverting dataset to history id {revert_request.history_id}. Reason: {revert_request.reason}.",
         config=config
     )
 


### PR DESCRIPTION
# Provena PR (Bug Fix): Revert Metadata Reason Fix

## Checklist

-   [x] If tests are required for this change, are they implemented?
-   [x] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [x] If migrations are required, is the process documented below?
-   [x] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [x] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [x] If change requires update to the [manual testing runsheet](https://confluence.csiro.au/pages/viewpage.action?pageId=1701138616), is there a task to track it and/or is it completed?

## Description

Fix for update metadata omits reason during metadata revert. Have tested the API directly and via UI to view the reason as well. 
See the metadata history of this dataset: https://f1753-data.dev.rrap-is.com/dataset/10378.1/1954623?view=settings

## Ticket
[1753](https://jira.csiro.au/secure/RapidBoard.jspa?rapidView=4227&projectKey=RRAPIS&view=detail&selectedIssue=RRAPIS-1753)