### PR TITLE
docs: basic additions to main readme for new configuration approach 

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,7 +164,9 @@ Environment Variables:
     Set to 'true' for verbose output
 ```
 
-The central idea of this configuration approach is that each namespace/stage combination contains a set of files, which are gitignored by default in Provena, which are 'merged' into the user's clone of the Provena repository, allowing temporary access to private information without exposing it in git.
+The central idea of this configuration approach is that each namespace/stage combination contains a set of files, which are gitignored by default in Provena, which are 'merged' into the user's clone of the Provena repository, allowing temporary access to private information without exposing it in git. 
+
+Sample configuration files are provided in various spots to help get started, including the [template config repo](https://github.com/provena/provena-config-repo-template).
 
 ### Config path caching
 
@@ -190,7 +192,7 @@ This saves using the `--target` option on every `./config` invocation. You can s
 
 ## Config repository
 
-The config repository is structured carefully, a copy of the README of the [sample config repository](https://github.com/provena/provena-config-repo-template) is included below
+The config repository is structured carefully, a copy of the README of the [sample config repository](https://github.com/provena/provena-config-repo-template) is included below:
 
 ### Purpose
 

--- a/README.md
+++ b/README.md
@@ -170,7 +170,7 @@ Sample configuration files are provided in various spots to help get started, in
 
 ### Config path caching
 
-The script builds in functionality to cache the repo which makes available a given namespace/stage combination. These are stored in `env.json` and has a structure like so:
+The script builds in functionality to cache the repo which makes available a given namespace/stage combination. These are stored in `env.json`, at the repository root, which has a structure like so:
 
 ```json
 {
@@ -196,17 +196,17 @@ The config repository is structured carefully, a copy of the README of the [samp
 
 ### Purpose
 
-This repository contains configuration files for the Provena project. It serves as a centralized location for managing configuration across different environments and components of the Provena system. This configuration is a mix of sensitive and non-sensitive information, but it is managed centrally to simplify this process.
+The configuration repository contains configuration files for the Provena project. It serves as a centralized location for managing configuration across different environments and components of the Provena system. This configuration is a mix of sensitive and non-sensitive information, but it is managed centrally to simplify this process.
 
 **Warning: while this repo is private, please don't commit secrets to it, instead commit references/IDs for those secrets stored in AWS Secret Manager**
 
 ### `cdk.context.json`
 
-This repo does not contain sample `cdk.context.json` files, but we recommend including this in this repo to make sure deployments are deterministic. This will be generated upon first CDK deploy.
+The configuration repo does not contain sample `cdk.context.json` files, but we recommend including this in this repo to make sure deployments are deterministic. This will be generated upon first CDK deploy.
 
 ### Structure
 
-The repository is organized using a hierarchical structure based on namespaces and stages:
+The configuration repository is organized using a hierarchical structure based on namespaces and stages:
 
 ```
 .

--- a/README.md
+++ b/README.md
@@ -8,8 +8,9 @@ To facilitate system functionality, Provena implements a suite of components. Ea
 
 ## Citations
 
-### Conference paper 
-Yu, J., Baker, P., Cox, S.J.D., Petridis, R., Freebairn, A.C., Mirza, F., Thomas, L., Tickell, S., Lemon, D. and Rezvani, M., Provena: A provenance system for large distributed modelling and simulation workflows, In Vaze, J., Chilcott, C., Hutley, L. and Cuddy, S.M. (eds) MODSIM2023, 25th International Congress on Modelling and Simulation. Modelling and Simulation Society of Australia and New Zealand, July 2023, pp. 14–20. ISBN: 978-0-9872143-0-0. https://doi.org/10.36334/modsim.2023.yu90 
+### Conference paper
+
+Yu, J., Baker, P., Cox, S.J.D., Petridis, R., Freebairn, A.C., Mirza, F., Thomas, L., Tickell, S., Lemon, D. and Rezvani, M., Provena: A provenance system for large distributed modelling and simulation workflows, In Vaze, J., Chilcott, C., Hutley, L. and Cuddy, S.M. (eds) MODSIM2023, 25th International Congress on Modelling and Simulation. Modelling and Simulation Society of Australia and New Zealand, July 2023, pp. 14–20. ISBN: 978-0-9872143-0-0. https://doi.org/10.36334/modsim.2023.yu90
 
 ### Software citation
 
@@ -51,8 +52,8 @@ The Provena Provenance API enables the registration of workflow provenance recor
 
 There are two primary registration mechanisms:
 
--   individual record registration (using the Pydantic models directly)
--   CSV bulk model run record ingestion (using a job queue workflow deployed separately)
+- individual record registration (using the Pydantic models directly)
+- CSV bulk model run record ingestion (using a job queue workflow deployed separately)
 
 Workflow provenance can support transparency of the modelling activities and facilitate repetition of the knowledge generation activity. Provenance can also assist in determining the integrity of certain knowledge and knowledge generation activities where important decisions are based off of this knowledge.
 
@@ -60,8 +61,8 @@ The Provena Provenance Store UI is a Typescript React GUI which enables user fri
 
 This UI facilitates
 
--   interactive visualisation of provenance graphs
--   tooling to assist with bulk registration of provenance model run activities
+- interactive visualisation of provenance graphs
+- tooling to assist with bulk registration of provenance model run activities
 
 and more...
 
@@ -73,10 +74,10 @@ For more info on the Provena Provenance API and UI:
 
 The Provena Auth API provides a set of user and admin tools which assists with:
 
--   creating, viewing and managing system access requests
--   generating access reports which assess the current users access to the components configured in the system Authorisation Model
--   creating, querying and managing user groups
--   managing the User to Registry Person Link
+- creating, viewing and managing system access requests
+- generating access reports which assess the current users access to the components configured in the system Authorisation Model
+- creating, querying and managing user groups
+- managing the User to Registry Person Link
 
 The Auth API is used heavily by other APIs as it communicates with the User groups table to enable querying of group membership. This group information is used to enforce resource level permissions on registry items.
 
@@ -91,7 +92,6 @@ The Search API is used across many of the Provena UIs as a simple way to search 
 
 For more info on the Search API:  
 [Search API Readme](./search-api/README.md)
-
 
 ## Technologies Used
 
@@ -111,7 +111,7 @@ Once a Provena deployment has been configured and deployed as per the above guid
 
 Provena comes with a suite of fully developed User Interface web pages that facilitate a user friendly interaction with the Provena APIs and resources.
 
-Additionally, all  Provena services can be accessed by authorised users through the system APIs. Provena has well documented REST APIs (see API endpoint documentation in READMEs) which can be interacted with directly using a REST client such as Postman or thunderclient, or programmatically using Python, for example. Programmatic interactions are recommended for our power users and we have guide on authentication for this. See our API access docs: [API access docs](http://docs.provena.io/API-access/).
+Additionally, all Provena services can be accessed by authorised users through the system APIs. Provena has well documented REST APIs (see API endpoint documentation in READMEs) which can be interacted with directly using a REST client such as Postman or thunderclient, or programmatically using Python, for example. Programmatic interactions are recommended for our power users and we have guide on authentication for this. See our API access docs: [API access docs](http://docs.provena.io/API-access/).
 
 ## Testing
 
@@ -127,9 +127,305 @@ The Provena repo contains a dedicated integration testing directory, separate fr
 
 These are some basic end-to-end system tests which test core functionality pathways to detect and prevent feature regression as new features are developed. These tests interact with the User Interfaces. For more info and to run the tests, see the [system tests readme](./tests/system/README.md).
 
-## Documentation
+# Configuring Provena
+
+Provena features a detached configuration management approach. This means that configuration should be stored in a separate private repository. Provena provides a set of utilities which interact with this configuration repository, primary the `./config` bash script.
+
+```text
+config - Configuration management tool for interacting with a private configuration repository
+
+Usage:
+  config NAMESPACE STAGE [OPTIONS]
+  config --help | -h
+  config --version | -v
+
+Options:
+  --target, -t REPO_CLONE_STRING
+    The repository clone string
+
+  --repo-dir, -d PATH
+    Path to the pre-cloned repository
+
+  --help, -h
+    Show this help
+
+  --version, -v
+    Show version number
+
+Arguments:
+  NAMESPACE
+    The namespace to use (e.g., 'rrap')
+
+  STAGE
+    The stage to use (e.g., 'dev', 'stage')
+
+Environment Variables:
+  DEBUG
+    Set to 'true' for verbose output
+```
+
+The central idea of this configuration approach is that each namespace/stage combination contains a set of files, which are gitignored by default in Provena, which are 'merged' into the user's clone of the Provena repository, allowing temporary access to private information without exposing it in git.
+
+### Config path caching
+
+The script builds in functionality to cache the repo which makes available a given namespace/stage combination. These are stored in `env.json` and has a structure like so:
+
+```json
+{
+  "namespace": {
+    "stage1": "git@github.com:org/repo.git",
+    "stage2": "git@github.com:org/repo.git",
+    "stage3": "git@github.com:org/repo.git"
+  }
+}
+```
+
+This saves using the `--target` option on every `./config` invocation. You can share this file between team members, but we do not recommend committing it to your repository.
+
+## Config definitions
+
+**Namespace**: This is a grouping that we provide to allow you to separate standalone sets of configurations into distinct groups. For example, you may manage multiple organisation's configurations in one repo. You can just use a single namespace if suitable.
+
+**Stage**: A stage is a set of configurations within a namespace. This represents a 'deployment' of Provena.
+
+## Config repository
+
+The config repository is structured carefully, a copy of the README of the [sample config repository](https://github.com/provena/provena-config-repo-template) is included below
+
+### Purpose
+
+This repository contains configuration files for the Provena project. It serves as a centralized location for managing configuration across different environments and components of the Provena system. This configuration is a mix of sensitive and non-sensitive information, but it is managed centrally to simplify this process.
+
+**Warning: while this repo is private, please don't commit secrets to it, instead commit references/IDs for those secrets stored in AWS Secret Manager**
+
+### `cdk.context.json`
+
+This repo does not contain sample `cdk.context.json` files, but we recommend including this in this repo to make sure deployments are deterministic. This will be generated upon first CDK deploy.
+
+### Structure
+
+The repository is organized using a hierarchical structure based on namespaces and stages:
+
+```
+.
+├── README.md
+└── <your-namespace>
+    ├── base
+    ├── dev
+    └── feat
+```
+
+#### Namespaces
+
+A namespace represents a set of related deployment stages, usually one namespace per organisation/use case.
+
+#### Stages
+
+Within each namespace, there are multiple stages representing different environments/deployment specifications
+
+- `base`: Contains common base configurations shared across all stages within the namespace
+- `dev`: Sample development environment configurations
+- `feat`: Sample feature branch workflow environment configurations
+
+#### Feat stage
+
+The feat stage supports the feature branch deployment workflow which is now a part of the open-source workflow. This makes use of environment variable substitution which is described later.
+
+### File Organization
+
+Configuration files are placed within the appropriate namespace and stage directories. Currently:
+
+```
+.
+├── README.md
+└── your-namespace
+    ├── base
+    │   ├── admin-tooling
+    │   │   └── environments.json
+    │   └── utilities
+    │       └── supporting-stacks
+    │           ├── feature-branch-manager
+    │           │   └── configs
+    │           │       └── dev.json
+    │           └── github-creds
+    │               └── configs
+    │                   ├── build.json
+    │                   └── ops.json
+    ├── dev
+    │   └── infrastructure
+    │       └── configs
+    │           └── dev.json
+    └── feat
+        └── infrastructure
+            └── configs
+                ├── feat-ui.json
+                └── feat.json
+```
+
+### Usage by Provena config scripts
+
+#### Base Configurations
+
+Files in the `base` directory of a namespace are applied first, regardless of the target stage. This allows you to define common configurations that are shared across all stages within a namespace.
+
+#### Stage-Specific Configurations
+
+Files in stage-specific directories (e.g., `dev`, `test`, `prod`) are applied after the base configurations. They can override or extend the base configurations as needed.
+
+### Interaction with Provena Repository
+
+The main Provena repository contains a configuration management script that interacts with this configuration repository. Here's how it works:
+
+1. The script clones or uses a pre-cloned version of this configuration repository.
+2. It then copies the relevant configuration files based on the specified namespace and stage.
+3. The process follows these steps:
+   a. Copy all files from the `<namespace>/base/` directory (if it exists).
+   b. Copy all files from the `<namespace>/<stage>/` directory, potentially overwriting files from the base configuration.
+4. The copied configuration files are then used by the Provena system for the specified namespace and stage.
+
+### Best Practices
+
+1. Use version control: Commit and push changes to this repository regularly.
+2. Document changes: Use clear, descriptive commit messages and update this README if you make structural changes.
+3. Minimize secrets: Avoid storing sensitive information like passwords or API keys directly in these files. Instead, use secure secret management solutions.
+
+### Config variable substitution syntax
+
+This project supports a syntax for environment variable substitution within JSON files. This feature allows you to create dynamic JSON configurations that can adapt to different environments without modifying the JSON itself.
+
+#### Basic Syntax
+
+The basic syntax for environment variable substitution is:
+
+```
+${VARIABLE_NAME}
+```
+
+When the JSON is processed, this will be replaced with the value of the environment variable `VARIABLE_NAME`.
+
+### Advanced Syntax
+
+#### Default Values
+
+You can specify a default value to use if the environment variable is not set:
+
+```
+${VARIABLE_NAME:-default_value}
+```
+
+#### Conditional Substitution
+
+For more complex scenarios, you can use conditional substitution:
+
+```
+${VARIABLE_NAME?value_if_set||value_if_not_set}
+```
+
+### Examples
+
+Here are some examples to illustrate the different substitution patterns:
+
+1. Basic substitution:
+
+   ```json
+   {
+     "database_url": "${DB_URL}",
+     "port": ${PORT:-8080}
+   }
+   ```
+
+2. Conditional substitution:
+
+   ```json
+   {
+     "debug_mode": "${DEBUG?'true'||'false'}",
+     "log_level": "${LOG_LEVEL?'debug'||'info'}"
+   }
+   ```
+
+3. In-line substitution:
+
+   ```json
+   {
+     "api_endpoint": "https://${API_HOST:-api.example.com}:${API_PORT:-443}/v1"
+   }
+   ```
+
+4. Complex conditional substitution:
+   ```json
+   {
+     "database": {
+       "host": "${DB_HOST}",
+       "port": "${DB_PORT?!!||5432}",
+       "ssl": "${DB_SSL?true||false}",
+       "ssl_cert": "${DB_SSL?'${SSL_CERT_PATH}'||null}"
+     }
+   }
+   ```
+
+### Special Case: Self-Referential Substitution with quotation stripping
+
+A particularly useful pattern is the self-referential substitution with quotation stripping.
+
+```json
+{
+  "git_commit_id": "${GIT_COMMIT_ID?'!!'||null}"
+}
+```
+
+The goal of the above syntax is to
+
+- allow you to have control over whether the output is quoted or not
+- ensure the original JSON remains valid/parseable before substitution
+- allow you to reference the variable value as part of conditional logic
+
+There is a special condition in the config script as follows
+
+**If a conditional substitution is directly surrounded by double quotes, then remove those double quotes from the output**
+
+There are also two general rules:
+
+- always replace `'` with `"`
+- always replace `!!` with the value of the variable
+
+Combining these two features means
+
+```json
+{
+  "git_commit_id": "${GIT_COMMIT_ID?'!!'||null}"
+}
+```
+
+can resolve to two values
+
+- if `GIT_COMMIT_ID` is not "falsey" (i.e. not defined or literal value 'false') then the output will be
+
+```
+{
+  "git_commit_id": "123456"
+}
+```
+
+- if `GIT_COMMIT_ID` is not defined then
+
+```
+{
+  "git_commit_id": null
+}
+```
+
+## Using the config script
+
+Given the above information, a common use would be to 'checkout' configuration files for a target deployment to operate the system, e.g.
+
+```bash
+./config namespace stage
+```
+
+# Documentation
 
 ### General Provena Docs
+
 [Click here for general purpose Provena documentation](http://docs.provena.io/)
 
 ### API endpoint documentation
@@ -150,19 +446,19 @@ Contact Provena Developers via [https://www.csiro.au/en/contact](https://www.csi
 
 ## Acknowledgements
 
-The development of Provena Version 1.0 was funded by Reef Restoration and Adaptation Program (RRAP), which is a  partnership between the Australian Government’s Reef Trust and the Great Barrier Reef Foundation. Provena has been developed to support the Modelling and Decision Support (MDS) Subprogram (https://gbrrestoration.org/program/modelling-and-decision-support/). 
+The development of Provena Version 1.0 was funded by Reef Restoration and Adaptation Program (RRAP), which is a partnership between the Australian Government’s Reef Trust and the Great Barrier Reef Foundation. Provena has been developed to support the Modelling and Decision Support (MDS) Subprogram (https://gbrrestoration.org/program/modelling-and-decision-support/).
 
 People who contributed and developed Provena (ordered alphabetically):
--   Andrew Freebairn
--   David Lemon
--   Fareed Mirza
--   Jevy Wang
--   Jonathan Yu
--   Linda Thomas
--   Omid Rezvani
--   Peter Baker
--   Ross Petridis
--   Sharon Tickell
--   Simon Cox
--   Xinyu Hou
 
+- Andrew Freebairn
+- David Lemon
+- Fareed Mirza
+- Jevy Wang
+- Jonathan Yu
+- Linda Thomas
+- Omid Rezvani
+- Peter Baker
+- Ross Petridis
+- Sharon Tickell
+- Simon Cox
+- Xinyu Hou

--- a/infrastructure/README.md
+++ b/infrastructure/README.md
@@ -160,16 +160,11 @@ The Provena application cannot be deployed without a minimum set of existing res
 
 Provena has a workflow to manage configuration.
 
-In the `configs` folder you will see two files:
+The `configs` folder contains json files which configure the provena CDK application. We provide a `sample.json` file which shows the basic structure of the configuration, but the definition of the config class itself is visible in `provena/config/config_class.py`. 
 
--   `config_map.py`
--   `template_custom_deployment.py`
+Wherever a `CONFIG_ID` is referenced, it is assumed that the name of the corresponding config file is `${CONFIG_ID}.json`. For example, if your `CONFIG_ID` is "dev", then your json file must be named `dev.json`. 
 
-The config map defines a mapping from a config ID to a function which generates a `ProvenaConfig` object.
-
-The `template_custom_deployment` provides a scaffold to get started with your Provena application config.
-
-It is worth noting that all of the commands mentioned in 'Deploying and managing Provena' relate to a specific Config ID - so choose a helpful short hand for your application.
+CDK relies on the configuration approach used at the repo level for Provena, please see [the root README](../README.md) for more information.
 
 ## Deploying and managing Provena
 
@@ -177,16 +172,27 @@ It is worth noting that all of the commands mentioned in 'Deploying and managing
 
 The below steps assume that you have a defined Config ID which is setup as above. The commands will refer to the config ID as <config_id>.
 
+### Using the config script to setup your configuration
+
+Before running the below commands, use the config helper script in the root of the repo to setup your target deployment config, e.g. 
+
+```bash
+cd ..
+./config namespace stage
+```
+
+You should now refer to the stage's json file to configure the CDK application.
+
 ### How do we run CDK commands
 
-CDK includes a rich CLI which helps to deploy, update and diff applications. However, by default, we can only define a single app target - normally `app.py`. Due to Provena's deployment requirements, we have multiple CDK app files.
+CDK includes a rich CLI which helps to deploy, update and diff applications.
 
-The CLI tool enables the specification of a cdk file (`--app`) and and output cdk synth path (`--output`). These are customised as part of the config process.
+The CLI tool enables the specification of an output cdk synth path (`--output`). These are customised as part of the config process.
 
 We have defined a helper [typer cli](https://typer.tiangolo.com/typer-cli/) script which:
 
--   looks up the config id from the config map
--   generates the config with the specified generator function
+-   uses the config id and retrieves the corresponding JSON file
+-   generates the config by validating it against the Pydantic model, injecting some helpful environment variables as well in the pipeline (e.g. git hash/version information)
 -   reads the cdk app file, output path, and stack names
 -   generates a customised cdk command which has the required arguments and stack names, and includes the user's commands
 

--- a/utilities/supporting-stacks/feature-branch-manager/README.md
+++ b/utilities/supporting-stacks/feature-branch-manager/README.md
@@ -8,7 +8,7 @@ This CDK stack deploys infrastructure to, on a daily schedule, use the feature-b
 
 This project shares a configuration management approach from the main CDK infrastructure application.
 
-For more detailed explanation of the configuration setup, see `provena/infrastructure/README.md`.
+For more detailed explanation of the configuration setup, see [README](../../../README.md).
 
 To get setup
 

--- a/utilities/supporting-stacks/github-creds/README.md
+++ b/utilities/supporting-stacks/github-creds/README.md
@@ -2,17 +2,15 @@
 
 ## Purpose
 
-This CDK stack is very simple, it just deploys a GitHub connection credential
-which CodeBuild can use to authenticate with GitHub.
+This CDK stack is very simple, it just deploys a GitHub connection credential which CodeBuild can use to authenticate with GitHub.
 
-This is a dependency for the main CDK pipeline workflow, but is managed in a
-separate project to keep the main CDK app simple.
+This is a dependency for the main CDK pipeline workflow, but is managed in a separate project to keep the main CDK app simple.
 
 ## Config management
 
 This project shares a configuration management approach from the main CDK infrastructure application.
 
-For more detailed explanation of the configuration setup, see `provena/infrastructure/README.md`.
+For more detailed explanation of the configuration setup, see [README](../../../README.md).
 
 To get setup
 


### PR DESCRIPTION
# Provena PR (minor): basic additions to main readme for new configuration approach 

## Description

First go at explaining config management approach. Tries to make things consistent and remove references to stale configuration approaches. 

The next step, assuming this is okay, will be to update the Provena deploy from scratch docs to expose any missing pieces of documentation. This will be the most significant change in documentation needed.