### PR TITLE
Provena PR (Bug Fix): Improved wording for publisher field

### DIFF
--- a/data-store-api/resources/schema.json
+++ b/data-store-api/resources/schema.json
@@ -181,7 +181,7 @@
                     "$id": "#/properties/publisher_id",
                     "type": "string",
                     "title": "Publisher",
-                    "description": "Please provide information about the organisation which publishing/producing this dataset. If this is your organisation, please select it again using the tool below."
+                    "description": "Please provide information about the organisation which is publishing or producing this dataset. If this is your organisation, please select it again using the tool below."
                 },
                 "created_date": {
                     "$id": "#/properties/created_date",

--- a/data-store-api/resources/schema.json
+++ b/data-store-api/resources/schema.json
@@ -181,7 +181,7 @@
                     "$id": "#/properties/publisher_id",
                     "type": "string",
                     "title": "Publisher",
-                    "description": "Please provide information about the organisation which published/produced this dataset. If your organisation produced this dataset, please select it again using the tool below."
+                    "description": "Please provide information about the organisation which publishing/producing this dataset. If this is your organisation, please select it again using the tool below."
                 },
                 "created_date": {
                     "$id": "#/properties/created_date",

--- a/utilities/packages/python/provena-interfaces/ProvenaInterfaces/RegistryModels.py
+++ b/utilities/packages/python/provena-interfaces/ProvenaInterfaces/RegistryModels.py
@@ -1213,7 +1213,7 @@ class CollectionFormatDatasetInfo(BaseModel):
     publisher_id: str = Field(
         ...,
         title="Publisher",
-        description="Please provide information about the organisation which publishing/producing this dataset. If this is your organisation, please select it again using the tool below.",
+        description="Please provide information about the organisation which is publishing or producing this dataset. If this is your organisation, please select it again using the tool below.",
     )
 
     # created/published dates

--- a/utilities/packages/python/provena-interfaces/ProvenaInterfaces/RegistryModels.py
+++ b/utilities/packages/python/provena-interfaces/ProvenaInterfaces/RegistryModels.py
@@ -1213,7 +1213,7 @@ class CollectionFormatDatasetInfo(BaseModel):
     publisher_id: str = Field(
         ...,
         title="Publisher",
-        description="Please provide information about the organisation which published/produced this dataset. If your organisation produced this dataset, please select it again using the tool below.",
+        description="Please provide information about the organisation which publishing/producing this dataset. If this is your organisation, please select it again using the tool below.",
     )
 
     # created/published dates


### PR DESCRIPTION
# Provena PR (Bug Fix): Improved wording for publisher field

## Checklist

-   [ ] If tests are required for this change, are they implemented?
-   [ ] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [ ] If migrations are required, is the process documented below?
-   [ ] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [ ] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [ ] If change requires update to the [manual testing runsheet](https://confluence.csiro.au/pages/viewpage.action?pageId=1701138616), is there a task to track it and/or is it completed?

## Description

Slight improvement to the publisher field description wording after it was made optional inferring that a dataset is yet to be created or published.
