### PR TITLE
Adding node type to write queries based on category, and updating que…

### DIFF
--- a/admin-tooling/environment-bootstrapper/requirements.txt
+++ b/admin-tooling/environment-bootstrapper/requirements.txt
@@ -1,5 +1,5 @@
 mdsisclienttools
-typer[all]
+typer
 
 # Shared interfaces
 ../../utilities/packages/python/provena-interfaces

--- a/prov-api/helpers/prov_connector.py
+++ b/prov-api/helpers/prov_connector.py
@@ -1201,7 +1201,7 @@ class Neo4jGraphManager():
             # Create or merge nodes
             for node in graph.get_node_set():
                 cypher_query = f"""
-                MERGE (n:{node.category} {{id: $id}})
+                MERGE (n:{node.category.value} {{id: $id}})
                 SET n.item_subtype = $subtype,
                     n.item_category = $category,
                     n.record_ids = CASE
@@ -1523,7 +1523,7 @@ class GraphDiffApplier:
     def _handle_add_new_node(self, action: AddNewNode) -> None:
         with self.neo4j_manager.driver.session() as session:
             cypher_query = f"""
-            MERGE (n: {action.node.category} {{
+            MERGE (n: {action.node.category.value} {{
                 id: $id,
                 item_subtype: $subtype,
                 item_category: $category,

--- a/prov-api/helpers/prov_connector.py
+++ b/prov-api/helpers/prov_connector.py
@@ -375,7 +375,7 @@ def special_contributing_agent_query(starting_id: str, depth: int, config: Confi
         raise RuntimeError(
             "Asking for real data from graph DB during mock! Returning [].")
 
-    # The cypher query to make for upstream lineage - only concerned with datasets upstream
+    # The cypher query to make for upstream lineage - only concerned with agents upstream
     query = f"""
     MATCH r=((parent : AGENT) <-[*1..{depth}]-(start{{`{IDENTIFIER_TAG}`:'{starting_id}'}})) RETURN r
     """


### PR DESCRIPTION
Adding node type to write queries based on category, and updating queries to use fully capitalised node labels. 

Fixes bug where user would observe empty graph responses from special upstream and downstream queries which filtered on item category.

## Migrations Required

See #55 migration - i.e. clear and rebuild prov graph.

## Feature deployment

Feature branch name: **feat-1813-special-query-fix**

URL Prefix: f1813

Pipeline links: [pipelines](https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines?region=ap-southeast-2&pipelines-meta=eyJmIjp7InRleHQiOiJmMTgxMyJ9LCJzIjp7InByb3BlcnR5IjoidXBkYXRlZCIsImRpcmVjdGlvbiI6LTF9LCJuIjoxMCwiaSI6MH0K)

Deployed components:

[landing-portal](https://f1813.dev.rrap-is.com/)

[job-api](https://f1813-job-api.dev.rrap-is.com/)

[data-store-api](https://f1813-data-api.dev.rrap-is.com/)

[data-store-ui](https://f1813-data.dev.rrap-is.com/)

[auth-api](https://f1813-auth-api.dev.rrap-is.com/)

[prov-api](https://f1813-prov-api.dev.rrap-is.com/)

[prov-ui](https://f1813-prov.dev.rrap-is.com/)

[registry-api](https://f1813-registry-api.dev.rrap-is.com/)

[registry-ui](https://f1813-registry.dev.rrap-is.com/)

To tear down feature deployment: ./fb destroy 1813 special-query-fix