### PR TITLE
feat (minor): Completion of the "Edit-Model-Run" from Registry UI front-end functionality.

### DIFF
--- a/prov-ui/src/pages/RegistrationTools.tsx
+++ b/prov-ui/src/pages/RegistrationTools.tsx
@@ -29,6 +29,13 @@ import { BoundedContainer, useTypedQueryStringVariable } from "react-libs";
 import { CreateModelRunTool } from "./CreateModelRunTool";
 import { UpdateModelRunTool } from "./UpdateModelRunTool";
 
+export const TOOL_TAB_IDS = {
+  GENERATE_TEMPLATE: 0,
+  LODGE_TEMPLATE: 1,
+  CREATE: 2,
+  EDIT: 3,
+};
+
 const useStyles = makeStyles((theme: Theme) =>
   createStyles({
     root: {
@@ -72,23 +79,26 @@ const RegistrationTools = observer(() => {
   const { keycloak, initialized } = useKeycloak();
 
   // Parent component holds the requested edit model run id.
-  const [modelRunId, setModelRunId] = useState<string|undefined>(undefined)
+  const [modelRunId, setModelRunId] = useState<string | undefined>(undefined);
 
-  // Query string parser
-  const {value, setValue} = useTypedQueryStringVariable({
-    queryStringKey: "recordId", 
-    defaultValue:undefined
-  })
+  // Query string parser for model run record Id
+  const { value: modelRunIdQString, setValue: setModelRunIdQString } =
+    useTypedQueryStringVariable({
+      queryStringKey: "recordId",
+      defaultValue: undefined,
+    });
 
-  // useEffect to change form tabs if query string exists.
+  // useEffect to change form tabs if query string exists and strip off the
+  // model run record id
   useEffect(() => {
-    if (value !== undefined){
-      setCurrentTab(3)
-      setModelRunId(value)
+    if (modelRunIdQString !== undefined) {
+      // move to model run edit tab
+      setCurrentTab(TOOL_TAB_IDS.EDIT);
+      setModelRunId(modelRunIdQString);
       // Value of the query string is stripped, to prevent persistent auto-complete of the forms.
-      setValue?.(undefined)
-      } 
-  }, [value])
+      setModelRunIdQString?.(undefined);
+    }
+  }, [modelRunIdQString]);
 
   // Firstly - make sure we have access
   useEffect(() => {
@@ -101,36 +111,6 @@ const RegistrationTools = observer(() => {
 
   if (!initialized) {
   }
-
-  // Define the error dialog fragment in case something goes wrong with the
-  // access check process
-  const dialogFragment = (
-    <React.Fragment>
-      {
-        //Error dialogue based on store state
-      }
-      <Dialog open={accessStore.error}>
-        <DialogTitle> Access check error! </DialogTitle>
-        <DialogContent>
-          <DialogContent>
-            <p>
-              The system experienced an issue while trying to check your system
-              access. <br />
-              Error message:{" "}
-              {accessStore.errorMessage ?? "No error message provided."}
-              <br />
-              Press <i>Dismiss</i> to attempt interacting with the prov store
-              anyway. If you are definitely authorised and still see this error,
-              please use the <i>Contact Us</i> link to report an issue.
-            </p>
-          </DialogContent>
-        </DialogContent>
-        <DialogActions>
-          <Button onClick={() => accessStore.dismissError()}>Dismiss</Button>
-        </DialogActions>
-      </Dialog>
-    </React.Fragment>
-  );
 
   // If there is an issue with access, prompt re-login
   if (accessStore.loading) {
@@ -273,17 +253,26 @@ const RegistrationTools = observer(() => {
             )}
           </Grid>
           <Grid item xs={sideBar ? 10 : 11.5} className={classes.tabPanel}>
-            <TabPanel index={0} currentIndex={currentTab}>
+            <TabPanel
+              index={TOOL_TAB_IDS.GENERATE_TEMPLATE}
+              currentIndex={currentTab}
+            >
               <GenerateTemplate />
             </TabPanel>
-            <TabPanel index={1} currentIndex={currentTab}>
+            <TabPanel
+              index={TOOL_TAB_IDS.LODGE_TEMPLATE}
+              currentIndex={currentTab}
+            >
               <LodgeTemplate />
             </TabPanel>
-            <TabPanel index={2} currentIndex={currentTab}>
+            <TabPanel index={TOOL_TAB_IDS.CREATE} currentIndex={currentTab}>
               <CreateModelRunTool />
             </TabPanel>
-            <TabPanel index={3} currentIndex={currentTab}>
-              <UpdateModelRunTool modelRunId={modelRunId} reset={() => setModelRunId(undefined)}></UpdateModelRunTool>
+            <TabPanel index={TOOL_TAB_IDS.EDIT} currentIndex={currentTab}>
+              <UpdateModelRunTool
+                modelRunId={modelRunId}
+                reset={() => setModelRunId(undefined)}
+              ></UpdateModelRunTool>
             </TabPanel>
           </Grid>
         </Grid>

--- a/prov-ui/src/pages/RegistrationTools.tsx
+++ b/prov-ui/src/pages/RegistrationTools.tsx
@@ -71,18 +71,24 @@ const RegistrationTools = observer(() => {
   const [sideBar, setSideBar] = useState(true);
   const { keycloak, initialized } = useKeycloak();
 
+  // Parent component holds the requested edit model run id.
+  const [modelRunId, setModelRunId] = useState<string|undefined>(undefined)
+
   // Query string parser
-  const {value} = useTypedQueryStringVariable({
+  const {value, setValue} = useTypedQueryStringVariable({
     queryStringKey: "recordId", 
     defaultValue:undefined
   })
 
-  // useEffect to change form tabs, that runs on component load.
+  // useEffect to change form tabs if query string exists.
   useEffect(() => {
     if (value !== undefined){
       setCurrentTab(3)
-    }
-  }, [])
+      setModelRunId(value)
+      // Value of the query string is stripped, to prevent persistent auto-complete of the forms.
+      setValue?.(undefined)
+      } 
+  }, [value])
 
   // Firstly - make sure we have access
   useEffect(() => {
@@ -277,11 +283,7 @@ const RegistrationTools = observer(() => {
               <CreateModelRunTool />
             </TabPanel>
             <TabPanel index={3} currentIndex={currentTab}>
-              {value ? (
-                <UpdateModelRunTool modelRunId={value} />
-              ) : (
-                <UpdateModelRunTool />
-              )}
+              <UpdateModelRunTool modelRunId={modelRunId} reset={() => setModelRunId(undefined)}></UpdateModelRunTool>
             </TabPanel>
           </Grid>
         </Grid>

--- a/prov-ui/src/pages/RegistrationTools.tsx
+++ b/prov-ui/src/pages/RegistrationTools.tsx
@@ -277,11 +277,11 @@ const RegistrationTools = observer(() => {
               <CreateModelRunTool />
             </TabPanel>
             <TabPanel index={3} currentIndex={currentTab}>
-              if(value){
+              {value ? (
                 <UpdateModelRunTool modelRunId={value} />
-              } else {
-                <UpdateModelRunTool/>
-              }
+              ) : (
+                <UpdateModelRunTool />
+              )}
             </TabPanel>
           </Grid>
         </Grid>

--- a/prov-ui/src/pages/RegistrationTools.tsx
+++ b/prov-ui/src/pages/RegistrationTools.tsx
@@ -25,7 +25,7 @@ import GenerateTemplate from "../subpages/GenerateTemplate";
 import LodgeTemplate from "../subpages/LodgeTemplate";
 import KeyboardArrowLeftIcon from "@mui/icons-material/KeyboardArrowLeft";
 import KeyboardArrowRightIcon from "@mui/icons-material/KeyboardArrowRight";
-import { BoundedContainer } from "react-libs";
+import { BoundedContainer, useTypedQueryStringVariable } from "react-libs";
 import { CreateModelRunTool } from "./CreateModelRunTool";
 import { UpdateModelRunTool } from "./UpdateModelRunTool";
 
@@ -70,6 +70,19 @@ const RegistrationTools = observer(() => {
   const [currentTab, setCurrentTab] = useState(0);
   const [sideBar, setSideBar] = useState(true);
   const { keycloak, initialized } = useKeycloak();
+
+  // Query string parser
+  const {value} = useTypedQueryStringVariable({
+    queryStringKey: "recordId", 
+    defaultValue:undefined
+  })
+
+  // useEffect to change form tabs, that runs on component load.
+  useEffect(() => {
+    if (value !== undefined){
+      setCurrentTab(3)
+    }
+  }, [])
 
   // Firstly - make sure we have access
   useEffect(() => {
@@ -264,7 +277,11 @@ const RegistrationTools = observer(() => {
               <CreateModelRunTool />
             </TabPanel>
             <TabPanel index={3} currentIndex={currentTab}>
-              <UpdateModelRunTool />
+              if(value){
+                <UpdateModelRunTool modelRunId={value} />
+              } else {
+                <UpdateModelRunTool/>
+              }
             </TabPanel>
           </Grid>
         </Grid>

--- a/prov-ui/src/pages/UpdateModelRunTool.tsx
+++ b/prov-ui/src/pages/UpdateModelRunTool.tsx
@@ -129,13 +129,22 @@ const MonitorResultComponent = (props: MonitorResultComponentProps) => {
   );
 };
 
-export const UpdateModelRunTool = () => {
+// Optional props to be used if a model run id is to be injected into the component.
+interface UpdateModelRunOptionalProps{
+  modelRunId?: string
+}
+
+export const UpdateModelRunTool = (props: UpdateModelRunOptionalProps | {}) => {
   /**
     Component: UpdateModelRunTool
 
     Lodge form page. Allows updating an existing record.
     
     */
+
+  // Declare the type of props if provided.  
+  const typedProps = props as UpdateModelRunOptionalProps;
+
   const [modelRunId, setModelRunId] = useState<string | undefined>(undefined);
   const [modelRunRecord, setModelRunRecord] = useState<
     ItemModelRun | undefined
@@ -155,6 +164,12 @@ export const UpdateModelRunTool = () => {
 
   const granted = !!auth.granted;
   const showUpdateForm = granted && canWriteToRecord && !showResult;
+
+  useEffect(() => {
+    if (typedProps && typedProps.modelRunId){
+      setModelRunId(typedProps.modelRunId)
+    }
+  }, [])
 
   useEffect(() => {
     // TODO replace with useFormSetup once API returns the data - this is hack!

--- a/prov-ui/src/pages/UpdateModelRunTool.tsx
+++ b/prov-ui/src/pages/UpdateModelRunTool.tsx
@@ -132,18 +132,16 @@ const MonitorResultComponent = (props: MonitorResultComponentProps) => {
 // Optional props to be used if a model run id is to be injected into the component.
 interface UpdateModelRunOptionalProps{
   modelRunId?: string
+  reset: () => void // Call back function that removes value from parent component.
 }
 
-export const UpdateModelRunTool = (props: UpdateModelRunOptionalProps | {}) => {
+export const UpdateModelRunTool = (props: UpdateModelRunOptionalProps) => {
   /**
     Component: UpdateModelRunTool
 
     Lodge form page. Allows updating an existing record.
     
     */
-
-  // Declare the type of props if provided.  
-  const typedProps = props as UpdateModelRunOptionalProps;
 
   const [modelRunId, setModelRunId] = useState<string | undefined>(undefined);
   const [modelRunRecord, setModelRunRecord] = useState<
@@ -167,12 +165,14 @@ export const UpdateModelRunTool = (props: UpdateModelRunOptionalProps | {}) => {
 
   /* Use effect that runs once on component load to check whether 
      a model run id was provided to the component. If model run id 
-     is provided, the state is set to the respective provided ID.
+     is provided, the state is set to the respective provided ID,
+     AND the model run id in the parent component is reset.
   */
   useEffect(() => {
-    if (typedProps && typedProps.modelRunId){
-      setModelRunId(typedProps.modelRunId)
-    }
+    if(props && props.modelRunId){
+      setModelRunId(props.modelRunId)
+      props.reset()
+  }
   }, [])
 
   useEffect(() => {

--- a/prov-ui/src/pages/UpdateModelRunTool.tsx
+++ b/prov-ui/src/pages/UpdateModelRunTool.tsx
@@ -165,6 +165,10 @@ export const UpdateModelRunTool = (props: UpdateModelRunOptionalProps | {}) => {
   const granted = !!auth.granted;
   const showUpdateForm = granted && canWriteToRecord && !showResult;
 
+  /* Use effect that runs once on component load to check whether 
+     a model run id was provided to the component. If model run id 
+     is provided, the state is set to the respective provided ID.
+  */
   useEffect(() => {
     if (typedProps && typedProps.modelRunId){
       setModelRunId(typedProps.modelRunId)

--- a/registry-ui/src/pages/Item.tsx
+++ b/registry-ui/src/pages/Item.tsx
@@ -546,6 +546,17 @@ const RecordView = observer((props: {}) => {
                     </Button>
                   </Grid>
                 )}
+                {isModelRun && (
+                  <Grid item>
+                    <Button 
+                      variant="outlined"
+                      className={classes.actionButton}
+                      href = {`${PROV_STORE_LINK}/tools?recordId=${handleId}`}
+                    >
+                    Edit Model Run
+                    </Button>
+                  </Grid>
+                )}
                 {seeAddStudyLinkButton && (
                   <Grid item>
                     <Button

--- a/registry-ui/src/pages/Item.tsx
+++ b/registry-ui/src/pages/Item.tsx
@@ -365,6 +365,12 @@ const RecordView = observer((props: {}) => {
     isModelRun &&
     typedPayload &&
     !!(typedPayload.item as ItemModelRun).record.study_id;
+  const showEditModelRunButton =
+    // Must have metadata write permission
+    writeCheck.fallbackGranted &&
+    // Must have entity loaded and subtype parsed
+    item !== undefined &&
+    subtype === "MODEL_RUN";
 
   const datastoreLink = isDataset
     ? `${DATA_STORE_LINK}/dataset/${params.idPrefix}/${params.idSuffix}`
@@ -546,14 +552,14 @@ const RecordView = observer((props: {}) => {
                     </Button>
                   </Grid>
                 )}
-                {isModelRun && (
+                {showEditModelRunButton && (
                   <Grid item>
-                    <Button 
+                    <Button
                       variant="outlined"
                       className={classes.actionButton}
-                      href = {`${PROV_STORE_LINK}/tools?recordId=${handleId}`}
+                      href={`${PROV_STORE_LINK}/tools?recordId=${handleId}`}
                     >
-                    Edit Model Run
+                      Edit Model Run
                     </Button>
                   </Grid>
                 )}


### PR DESCRIPTION
# feat(minor): Completion of the "Edit-Model-Run" from Registry UI front-end functionality.

## Checklist

-   [x] If tests are required for this change, are they implemented?
-   [x] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [x] If migrations are required, is the process documented below?
-   [x] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [X] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [x] If this change requires updates to the [Provena Python Client](https://github.com/provena/provena-python-client), is this accounted for?

## Description
This feature introduces an "Edit Model Run" button in the Registry UI for Model Run Records. When clicked, the button navigates the user to the registration tools functionality within the prov-store-ui. The corresponding update model run form is automatically populated with data from the selected model run record.

## Migrations Required
None

## Notes for reviewer
- I have utilised the QueryString hooks to extract the model run record ID from the URL.
- Based on the presence of the record ID, the prov-store-ui tools form conditionally renders specific sections.
- The form fields are populated with data passed via props from the original model run record.


## Feature Branch Information

https://f1815.dev.rrap-is.com/

Deployed components:

[landing-portal](https://f1815.dev.rrap-is.com/)

[job-api](https://f1815-job-api.dev.rrap-is.com/)

[data-store-api](https://f1815-data-api.dev.rrap-is.com/)

[data-store-ui](https://f1815-data.dev.rrap-is.com/)

[auth-api](https://f1815-auth-api.dev.rrap-is.com/)

[prov-api](https://f1815-prov-api.dev.rrap-is.com/)

[prov-ui](https://f1815-prov.dev.rrap-is.com/)

[registry-api](https://f1815-registry-api.dev.rrap-is.com/)

[registry-ui](https://f1815-registry.dev.rrap-is.com/)

To tear down feature deployment: ./fb destroy 1815 edit-model-run
