### PR TITLE
fix: production interfaces pipeline invalid distribution name & PyPI package name to staisfy625 and 

### DIFF
--- a/.github/workflows/publish-provena-interfaces.yml
+++ b/.github/workflows/publish-provena-interfaces.yml
@@ -15,10 +15,8 @@ jobs:
     steps:
     - name: Check tag format
       run: |
-        if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+$ ]]; then
-          echo "Tag format is incorrect. Expecting vX.X.X.X or vX.X.X or vX.X or vX. Please create a new release with the correct tag format."
-          exit 1
-        fi
+         if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+$ ]]; then
+          echo "Tag format is incorrect. Expecting vX.X.X or vX.X or Vx. Please create a new release with the correct tag format."
     
     - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-provena-interfaces.yml
+++ b/.github/workflows/publish-provena-interfaces.yml
@@ -72,6 +72,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
+        attestations: false
 
     - name: TEST install package from TEST PyPI
       run: |
@@ -79,3 +80,5 @@ jobs:
 
     - name: Publish package distributions to PROD PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        attestations: false

--- a/.github/workflows/publish-provena-interfaces.yml
+++ b/.github/workflows/publish-provena-interfaces.yml
@@ -15,8 +15,8 @@ jobs:
     steps:
     - name: Check tag format
       run: |
-        if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+$ ]]; then
-          echo "Tag format is incorrect. Expecting vX.X.X or vX.X or Vx. Please create a new release with the correct tag format."
+        if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+$ ]]; then
+          echo "Tag format is incorrect. Expecting vX.X.X.X or vX.X.X or vX.X or vX. Please create a new release with the correct tag format."
           exit 1
         fi
     

--- a/.github/workflows/publish-provena-interfaces.yml
+++ b/.github/workflows/publish-provena-interfaces.yml
@@ -72,7 +72,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
-
+        attestations: false
 
     - name: TEST install package from TEST PyPI
       run: |
@@ -80,3 +80,5 @@ jobs:
 
     - name: Publish package distributions to PROD PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
+      with:
+        attestations: false

--- a/.github/workflows/publish-provena-interfaces.yml
+++ b/.github/workflows/publish-provena-interfaces.yml
@@ -72,7 +72,7 @@ jobs:
       uses: pypa/gh-action-pypi-publish@release/v1
       with:
         repository-url: https://test.pypi.org/legacy/
-        attestations: false
+
 
     - name: TEST install package from TEST PyPI
       run: |
@@ -80,5 +80,3 @@ jobs:
 
     - name: Publish package distributions to PROD PyPI
       uses: pypa/gh-action-pypi-publish@release/v1
-      with:
-        attestations: false

--- a/.github/workflows/publish-provena-interfaces.yml
+++ b/.github/workflows/publish-provena-interfaces.yml
@@ -17,6 +17,8 @@ jobs:
       run: |
         if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+$ ]]; then
           echo "Tag format is incorrect. Expecting vX.X.X or vX.X or Vx. Please create a new release with the correct tag format."
+          exit 1
+        fi
     
     - uses: actions/checkout@v4
 

--- a/.github/workflows/publish-provena-interfaces.yml
+++ b/.github/workflows/publish-provena-interfaces.yml
@@ -15,7 +15,7 @@ jobs:
     steps:
     - name: Check tag format
       run: |
-         if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+$ ]]; then
+        if [[ ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+\.[0-9]+$ && ! $TAG_NAME =~ ^v[0-9]+$ ]]; then
           echo "Tag format is incorrect. Expecting vX.X.X or vX.X or Vx. Please create a new release with the correct tag format."
     
     - uses: actions/checkout@v4

--- a/utilities/packages/python/provena-interfaces/setup.py
+++ b/utilities/packages/python/provena-interfaces/setup.py
@@ -7,7 +7,7 @@ import re
 version = os.getenv('TAG_NAME', 'v0.1.0')
 
 setup(
-    name='provena-interfaces',
+    name='provena_interfaces',
     # format acceptably as 'v0.0.1' or '0.0.1',
     version=version,
     description='Interfaces for Provena Application (see https://provena.io)',


### PR DESCRIPTION
# (fix): PyPI package name to satisfy PEP625 and production pipeline invalid distribution name issue

## Ticket: RRAPIS-1834

## Checklist

-   [ ] If tests are required for this change, are they implemented?
-   [ ] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [ ] If migrations are required, is the process documented below?
-   [ ] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [ ] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [ ] If this change requires updates to the [Provena Python Client](https://github.com/provena/provena-python-client), is this accounted for?

The production upload of provena interfaces was failing despite the test upload working:
https://github.com/provena/provena/actions/runs/12152728867/job/33889624898

![image](https://github.com/user-attachments/assets/a67bc5dc-9ffd-4856-b175-c2c09eedbdab)

For fixing the prod interface pipeline upload, I disabled attestations as a quick fix. Not sure what they are or if we need. Otherwise fixes may require not using the standard github action. Changing the package name for the second issue did not resolve this one, they're independent issues. or maybe the github action, setup tools or something else needs upgrading. But dont really have much time.

To fix the naming issue warning from the email in the ticket link, I am using an underscore in the name now. There is no real way to test for 100% certainty if this is a correct fix as there are no previous warning in pipelines that I can confirm no longer exist. However, looking in the package names for previous versions, we can see there is now an underscore (see below). So this is a pretty good indication that it is a fix. A new pep feature mandates the replacement of .and - with underscores in project names. We don't actually use underscores btw.

see names. and now how the normalised name is now included in 2.10.2.2. 

[old 2.9 files with dash](https://pypi.org/project/provena-interfaces/2.9.1/#provena-interfaces-2.9.1.tar.gz)
![image](https://github.com/user-attachments/assets/0e2f3289-9af8-448d-8762-5987e8d4da5e)


[new 2.10.2.2 files with underscore](https://pypi.org/project/provena-interfaces/#provena_interfaces-2.10.2.2.tar.gz)

![image](https://github.com/user-attachments/assets/a3e192c4-e1b9-4a17-b6c3-66ac34542606)


here is the email again:

This email is notifying you of an upcoming deprecation that we have determined may affect you as a result of your recent upload to 'provena-interfaces'. 
In the future, PyPI will require all newly uploaded source distribution filenames to comply with [PEP 625](https://peps.python.org/pep-0625/). Any source distributions already uploaded will remain in place as-is and do not need to be updated. 
Specifically, your recent upload of 'provena-interfaces-2.10.2.tar.gz' is incompatible with PEP 625 because it does not contain the normalized project name 'provena_interfaces'. 
In most cases, this can be resolved by upgrading the version of your build tooling to a later version that supports PEP 625 and produces compliant filenames. 
If you have questions, you can email [admin@pypi.org](mailto:admin@pypi.org) to communicate with the PyPI [admin@pypi.org](mailto:admin@pypi.org) to communicate with the PyPI administrators.





Sorry had to rush this a bit


_Description here..._

## Migrations Required

### _Example migration_

_Description here_

-   Steps to migrate here

## Notes for reviewer

_... (Optional) Notes here..._

## Feature branch

Include the output of `./fb md` here if you are using a feature branch.
