### PR TITLE
fix: Fixed incorrect printing of output nodes in word document of generate-report functionality

### DIFF
--- a/prov-api/helpers/generate_report_helpers.py
+++ b/prov-api/helpers/generate_report_helpers.py
@@ -523,7 +523,7 @@ def generate_word_file(config: Config, node_collection: ReportNodeCollection) ->
             bold_run.bold = True
 
             # Add the rest of the remaining string.
-            paragraph.add_run(f": {model_run_node.display_name}, ")
+            paragraph.add_run(f": {output_node.display_name}, ")
             add_hyperlink(paragraph, text=output_node.id, url=BASE_HANDLE_URL + output_node.id)
             paragraph.add_run(text = "\n")
 


### PR DESCRIPTION
# (fix): Fixed incorrect printing of output nodes in word document of generate-report functionality

## Ticket: RRAPIS-1841

## Checklist

-   [ ] If tests are required for this change, are they implemented?
-   [ ] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [ ] If migrations are required, is the process documented below?
-   [ ] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [X] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [ ] If this change requires updates to the [Provena Python Client](https://github.com/provena/provena-python-client), is this accounted for?

## Description
This PR fix addresses the issue where incorrect display names were printed within the output section of the Word document sourced from the generate-report functionality. 

## Migrations Required
None

## Notes for reviewer
I have tested this change, locally pointing to the DEV Registry, at a study with multiple outputs (2 output datasets) BEFORE VS AFTER, and the issue is now fixed. 

As you can see, it was just the use of incorrect variables. I was using the model run outputs variable for the dataset outputs.

## Feature branch
Given this is such a small change, I don't think a feature branch needs to be spun up, and I have tested locally with DEV.
