### PR TITLE
(fix): Disabling template edit functionality (UI only)

### DIFF
--- a/registry-ui/src/entityLists.tsx
+++ b/registry-ui/src/entityLists.tsx
@@ -9,6 +9,11 @@ export const nonEditEntityTypes: ItemSubType[] = [
   "DATASET_TEMPLATE"
 ];
 
+export const nonCloneEntityTypes: ItemSubType[] = [
+  "DATASET",
+  "MODEL_RUN",
+];
+
 export const entityTypes: ItemSubType[] = [
   "DATASET",
   "DATASET_TEMPLATE",

--- a/registry-ui/src/entityLists.tsx
+++ b/registry-ui/src/entityLists.tsx
@@ -1,6 +1,11 @@
 import { DATA_STORE_LINK, DOCUMENTATION_BASE_URL } from "react-libs";
 import { ItemSubType } from "./provena-interfaces/RegistryModels";
 
+/** List of item subtypes that should not be edited from 
+within the Registry UI. Either they should never be edited
+(e.g., templates as this would break provenance) or they should
+be edited from the Datastore UI (datasets)
+*/
 export const nonEditEntityTypes: ItemSubType[] = [
   "DATASET",
   "MODEL_RUN",
@@ -9,6 +14,10 @@ export const nonEditEntityTypes: ItemSubType[] = [
   "DATASET_TEMPLATE"
 ];
 
+/** List of item subtypes that should not be cloned from 
+within the Registry UI. Either they should never be cloned,
+or only cloned from Datastore UI.
+*/
 export const nonCloneEntityTypes: ItemSubType[] = [
   "DATASET",
   "MODEL_RUN",
@@ -71,32 +80,32 @@ export const entityRegisterDocumentationMap: Map<ItemSubType, string> = new Map(
     [
       "DATASET_TEMPLATE",
       DOCUMENTATION_BASE_URL +
-        "/provenance/registering-model-runs/model-workflow-configuration.html#dataset-template",
+      "/provenance/registering-model-runs/model-workflow-configuration.html#dataset-template",
     ],
     [
       "MODEL",
       DOCUMENTATION_BASE_URL +
-        "/provenance/registering-model-runs/establishing-required-entities.html#model",
+      "/provenance/registering-model-runs/establishing-required-entities.html#model",
     ],
     [
       "MODEL_RUN_WORKFLOW_TEMPLATE",
       DOCUMENTATION_BASE_URL +
-        "/provenance/registering-model-runs/model-workflow-configuration.html#model-run-workflow-template",
+      "/provenance/registering-model-runs/model-workflow-configuration.html#model-run-workflow-template",
     ],
     [
       "ORGANISATION",
       DOCUMENTATION_BASE_URL +
-        "/provenance/registering-model-runs/establishing-required-entities.html#organisation",
+      "/provenance/registering-model-runs/establishing-required-entities.html#organisation",
     ],
     [
       "PERSON",
       DOCUMENTATION_BASE_URL +
-        "/provenance/registering-model-runs/establishing-required-entities.html#person",
+      "/provenance/registering-model-runs/establishing-required-entities.html#person",
     ],
     [
       "STUDY",
       DOCUMENTATION_BASE_URL +
-        "/provenance/registering-model-runs/establishing-required-entities.html#study",
+      "/provenance/registering-model-runs/establishing-required-entities.html#study",
     ],
   ],
 );

--- a/registry-ui/src/entityLists.tsx
+++ b/registry-ui/src/entityLists.tsx
@@ -1,7 +1,13 @@
 import { DATA_STORE_LINK, DOCUMENTATION_BASE_URL } from "react-libs";
 import { ItemSubType } from "./provena-interfaces/RegistryModels";
 
-export const nonEditEntityTypes: ItemSubType[] = ["DATASET", "MODEL_RUN"];
+export const nonEditEntityTypes: ItemSubType[] = [
+  "DATASET",
+  "MODEL_RUN",
+  "MODEL_RUN_WORKFLOW_TEMPLATE",
+  "WORKFLOW_TEMPLATE",
+  "DATASET_TEMPLATE"
+];
 
 export const entityTypes: ItemSubType[] = [
   "DATASET",

--- a/registry-ui/src/pages/Item.tsx
+++ b/registry-ui/src/pages/Item.tsx
@@ -347,7 +347,7 @@ const RecordView = observer((props: {}) => {
     item !== undefined &&
     subtype !== undefined &&
     // Must be editable type
-    nonEditEntityTypes.includes(subtype);
+    !nonEditEntityTypes.includes(subtype);
 
   const seeCloneButton =
     // Must have metadata write
@@ -356,7 +356,7 @@ const RecordView = observer((props: {}) => {
     item !== undefined &&
     subtype !== undefined &&
     // Must be editable type
-    nonCloneEntityTypes.includes(subtype);
+    !nonCloneEntityTypes.includes(subtype);
 
   const seeVersioning = !!subtype && subtypeHasVersioning(subtype);
 

--- a/registry-ui/src/pages/Item.tsx
+++ b/registry-ui/src/pages/Item.tsx
@@ -49,7 +49,10 @@ import {
 } from "react-libs";
 import { Link as RouteLink, useParams } from "react-router-dom";
 import { registryVersionIdLinkResolver } from "util/helper";
-import { nonEditEntityTypes } from "../entityLists";
+import {
+  nonEditEntityTypes,
+  nonCloneEntityTypes
+} from "../entityLists";
 import { ItemRevertResponse } from "../provena-interfaces/RegistryAPI";
 import {
   ItemBase,
@@ -353,7 +356,7 @@ const RecordView = observer((props: {}) => {
     item !== undefined &&
     subtype !== undefined &&
     // Must be editable type
-    nonEditEntityTypes.indexOf(subtype) === -1;
+    nonCloneEntityTypes.indexOf(subtype) === -1;
 
   const seeVersioning = !!subtype && subtypeHasVersioning(subtype);
 

--- a/registry-ui/src/pages/Item.tsx
+++ b/registry-ui/src/pages/Item.tsx
@@ -355,7 +355,7 @@ const RecordView = observer((props: {}) => {
     // Must have entity loaded and subtype parsed
     item !== undefined &&
     subtype !== undefined &&
-    // Must be editable type
+    // Must be cloneable type
     !nonCloneEntityTypes.includes(subtype);
 
   const seeVersioning = !!subtype && subtypeHasVersioning(subtype);

--- a/registry-ui/src/pages/Item.tsx
+++ b/registry-ui/src/pages/Item.tsx
@@ -347,7 +347,7 @@ const RecordView = observer((props: {}) => {
     item !== undefined &&
     subtype !== undefined &&
     // Must be editable type
-    nonEditEntityTypes.indexOf(subtype) === -1;
+    nonEditEntityTypes.includes(subtype);
 
   const seeCloneButton =
     // Must have metadata write
@@ -356,7 +356,7 @@ const RecordView = observer((props: {}) => {
     item !== undefined &&
     subtype !== undefined &&
     // Must be editable type
-    nonCloneEntityTypes.indexOf(subtype) === -1;
+    nonCloneEntityTypes.includes(subtype);
 
   const seeVersioning = !!subtype && subtypeHasVersioning(subtype);
 


### PR DESCRIPTION
# (fix): Disabling template edit functionality (UI only)
## Ticket: RRAPIS-1811

## Checklist

-   [ ] If tests are required for this change, are they implemented?
-   [ ] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [ ] If migrations are required, is the process documented below?
-   [ ] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [ ] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [ ] If this change requires updates to the [Provena Python Client](https://github.com/provena/provena-python-client), is this accounted for?

## Description
It was realised that editing Model Run Workflow Templates and Dataset Templates can produce in invalid entity states and provenance chains if the templates have been previously used.

This is a quick fix to revoke the ability for a user to edit template entities from the UI - achieved by conditionally removing the edit button for template entity types.

If users desire to make changes to a template, they should instead create a new version or clone, or if it really is a small issue like a typo in the name, they should consult admin team to do this change for them.

A blanket approach of disabling edits all together (as opposed to just the provenance breaking fields) was chosen because of severe time constraints in the dev team.

## Notes for reviewer.

Please observe and confirm the absence of the EDIT button in the item view page for dataset template and model run workflow template entities. Please observe and confirm the CLONE entity button existing same as before.

[Workflow template](https://f1811-registry.dev.rrap-is.com/item/10378.1/1969552)
[Dataset template](https://f1811-registry.dev.rrap-is.com/item/10378.1/1969548)

[Other entity](https://f1811-registry.dev.rrap-is.com/item/10378.1/1969573)
Check for both edit and clone buttons still existing, unchanged. 

## Feature branch
Feature branch name: feat-1811-disable-template-edits

URL Prefix: f1811

Pipeline links: https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines?region=ap-southeast-2&pipelines-meta=eyJmIjp7InRleHQiOiJmMTgxMSJ9LCJzIjp7InByb3BlcnR5IjoidXBkYXRlZCIsImRpcmVjdGlvbiI6LTF9LCJuIjoxMCwiaSI6MH0K

Deployed components:

landing-portal: https://f1811.dev.rrap-is.com/

data-store-api: https://f1811-data-api.dev.rrap-is.com/

job-api: https://f1811-job-api.dev.rrap-is.com/

data-store-ui: https://f1811-data.dev.rrap-is.com/

auth-api: https://f1811-auth-api.dev.rrap-is.com/

prov-api: https://f1811-prov-api.dev.rrap-is.com/

prov-ui: https://f1811-prov.dev.rrap-is.com/

registry-api: https://f1811-registry-api.dev.rrap-is.com/

registry-ui: https://f1811-registry.dev.rrap-is.com/

To tear down feature deployment: ./fb destroy 1811 disable-template-edits