### PR TITLE
(fix) Fix provenance graph legend colour mismatch

### DIFF
--- a/utilities/packages/typescript/react-libs/src/components/LegendItemInformation.tsx
+++ b/utilities/packages/typescript/react-libs/src/components/LegendItemInformation.tsx
@@ -58,7 +58,7 @@ export const LegendInformation: readonly LegendInformationProps[] = [
   },
   {
     colour: Swatches.modelRunWorkflowDefinitionSwatch.colour,
-    acronym: "MRWT",
+    acronym: "WT",
     name: "Model Run Workflow Template",
     href:
       DOCUMENTATION_BASE_URL +

--- a/utilities/packages/typescript/react-libs/src/util/subtypeStyling.tsx
+++ b/utilities/packages/typescript/react-libs/src/util/subtypeStyling.tsx
@@ -143,7 +143,7 @@ export const getSwatchForSubtype = (subtype: ItemSubType | undefined) => {
       baseSwatch = Swatches.softwareSwatch;
       break;
     case "WORKFLOW_TEMPLATE":
-      baseSwatch = Swatches.workflowDefinitonSwatch;
+      baseSwatch = Swatches.modelRunWorkflowDefinitionSwatch;
       break;
     case "WORKFLOW_RUN":
       baseSwatch = Swatches.workflowDefinitonSwatch;


### PR DESCRIPTION
# (fix): Fix provenance graph legend colour mismatch

## Ticket: RRAPIS-1822

## Checklist

-   [ ] If tests are required for this change, are they implemented?
-   [ ] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [ ] If migrations are required, is the process documented below?
-   [ ] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [ ] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [ ] If this change requires updates to the [Provena Python Client](https://github.com/provena/provena-python-client), is this accounted for?

## Description

It was noted that there is a mismatch in colours between the provenance graph and its legend component.

This appears to be due to Model Run Workflow Templates being served up with the `WORKFLOW_TEMPLATE` subtype, rather than the expected `MODEL_RUN_WORKFLOW_TEMPLATE` one instead. I cannot seem to find any entities that use the latter subtype.

## Notes for reviewer

I am unsure as to whether this small fix is appropriate, or if we should be looking at the item subtypes of the nodes returned by the provenance API's explore endpoints instead. Any advice would be appreciated.
