### PR TITLE
feat: Non RRAP Deployment Licences

### DIFF
--- a/data-store-ui/README.md
+++ b/data-store-ui/README.md
@@ -78,6 +78,20 @@ You could also update the documentation URL if desired - it defaults to the prov
 
 Once you have completed the env file, you should have a functional set of environment variables.
 
+### Customising dataset licence options
+
+The `cc_licenses.json` file located in the `./public` directory of this repository can be modified to add or remove dataset licence options as required.
+
+New licence entries should adhere to the following JSON format:
+
+```
+{
+    "name": "The short name or code of the chosen licence",
+    "title": "The formal title of the chosen licence",
+    "path": "The URL where the chosen licence details are published"
+}
+```
+
 ## Run
 
 To run the server locally (replacing provena with your chosen deployment target name as above)

--- a/data-store-ui/public/cc_licenses.json
+++ b/data-store-ui/public/cc_licenses.json
@@ -1,9 +1,9 @@
 {
-    "licences": [
+    "licenses": [
         {
             "name": "Copyright",
             "title": "All rights reserved",
-            "path": "https://gbrrestoration.github.io/rrap-mds-knowledge-hub/information-system/licenses.html#copyright-all-rights-reserved-"
+            "path": "https://docs.provena.io/licenses.html#copyright-all-rights-reserved-"
         },
         {
             "name": "CC0-1.0",

--- a/data-store-ui/public/cc_licenses.json
+++ b/data-store-ui/public/cc_licenses.json
@@ -49,11 +49,6 @@
             "name": "CC-BY-NC-SA-3.0",
             "title": "Creative Commons Attribution Non-Commercial Share-Alike 3.0",
             "path": "https://creativecommons.org/licenses/by-nc-sa/3.0/"
-        },
-        {
-            "name": "MIT",
-            "title": "The MIT License",
-            "path": "https://opensource.org/license/mit"
         }
     ]
 }

--- a/data-store-ui/public/cc_licenses.json
+++ b/data-store-ui/public/cc_licenses.json
@@ -49,6 +49,11 @@
             "name": "CC-BY-NC-SA-3.0",
             "title": "Creative Commons Attribution Non-Commercial Share-Alike 3.0",
             "path": "https://creativecommons.org/licenses/by-nc-sa/3.0/"
+        },
+        {
+            "name": "MIT",
+            "title": "The MIT License",
+            "path": "https://opensource.org/license/mit"
         }
     ]
 }

--- a/data-store-ui/public/cc_licenses.json
+++ b/data-store-ui/public/cc_licenses.json
@@ -1,0 +1,54 @@
+{
+    "licences": [
+        {
+            "name": "Copyright",
+            "title": "All rights reserved",
+            "path": "https://gbrrestoration.github.io/rrap-mds-knowledge-hub/information-system/licenses.html#copyright-all-rights-reserved-"
+        },
+        {
+            "name": "CC0-1.0",
+            "title": "Creative Commons Attribution 1.0 Universal",
+            "path": "https://creativecommons.org/publicdomain/zero/1.0/"
+        },
+        {
+            "name": "CC-BY-4.0",
+            "title": "Creative Commons Attribution 4.0",
+            "path": "https://creativecommons.org/licenses/by/4.0/"
+        },
+        {
+            "name": "CC-BY-SA-4.0",
+            "title": "Creative Commons Attribution Share-Alike 4.0",
+            "path": "https://creativecommons.org/licenses/by-sa/4.0/"
+        },
+        {
+            "name": "CC-BY-NC-4.0",
+            "title": "Creative Commons Attribution Non-Commercial 4.0",
+            "path": "https://creativecommons.org/licenses/by-nc/4.0/"
+        },
+        {
+            "name": "CC-BY-NC-SA-4.0",
+            "title": "Creative Commons Attribution Non-Commercial Share-Alike 4.0",
+            "path": "https://creativecommons.org/licenses/by-nc-sa/4.0/"
+        },
+        {
+            "name": "CC-BY-3.0",
+            "title": "Creative Commons Attribution 3.0",
+            "path": "https://creativecommons.org/licenses/by/3.0/"
+        },
+        {
+            "name": "CC-BY-SA-3.0",
+            "title": "Creative Commons Attribution Share-Alike 3.0",
+            "path": "https://creativecommons.org/licenses/by-sa/3.0/"
+        },
+        {
+            "name": "CC-BY-NC-3.0",
+            "title": "Creative Commons Attribution Non-Commercial 3.0",
+            "path": "https://creativecommons.org/licenses/by-nc/3.0/"
+        },
+        {
+            "name": "CC-BY-NC-SA-3.0",
+            "title": "Creative Commons Attribution Non-Commercial Share-Alike 3.0",
+            "path": "https://creativecommons.org/licenses/by-nc-sa/3.0/"
+        }
+    ]
+}

--- a/data-store-ui/src/components/AutoCompleteLicense.tsx
+++ b/data-store-ui/src/components/AutoCompleteLicense.tsx
@@ -115,7 +115,7 @@ const AutoCompleteLicense = (props: any) => {
 
   // Setup the initial license option list after initial load
   useEffect(() => {
-    fetch(`https://static.rrap-is.com/assets/cc_licenses.json`)
+    fetch(`/cc_licenses.json`)
       .then((res) => res.json())
       .then((json) => {
         // Get json API response


### PR DESCRIPTION
# feat: Non RRAP Deployment Licences

## Ticket: RRAPIS-1743, RRAPIS-1844

## Checklist

-   [ ] If tests are required for this change, are they implemented?
-   [ ] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [ ] If migrations are required, is the process documented below?
-   [ ] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [ ] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [ ] If this change requires updates to the [Provena Python Client](https://github.com/provena/provena-python-client), is this accounted for?

## Description

This branch moves the JSON file defining the various licences that can be applied to a dataset, which is currently hosted statically in an S3 bucket, to the datastore UI repository. This has been done to allow users to customise what licences are available for their own deployments, rather than relying on the ones chosen for the GBR project.

This branch also addresses the RRAPIS-1844 ticket, fixing the broken link for the first licence in the JSON file.

## Notes for reviewer

This is a UI only change, and can simply to pointed at the existing dev API's. Add or remove entries from the `/data-store-ui/public/cc_licenses.json` file, and ensure the licence dropdown in the dataset creation tool reflects your changes.

## Feature Branch

Feature branch name: **feat-1743-non-rrap-deployment-licences**

URL Prefix: f1743

Pipeline links: [pipelines](https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines?region=ap-southeast-2&pipelines-meta=eyJmIjp7InRleHQiOiJmMTc0MyJ9LCJzIjp7InByb3BlcnR5IjoidXBkYXRlZCIsImRpcmVjdGlvbiI6LTF9LCJuIjoxMCwiaSI6MH0K)

Deployed components:

[landing-portal](https://f1743.dev.rrap-is.com/)

[job-api](https://f1743-job-api.dev.rrap-is.com/)

[data-store-api](https://f1743-data-api.dev.rrap-is.com/)

[data-store-ui](https://f1743-data.dev.rrap-is.com/)

[auth-api](https://f1743-auth-api.dev.rrap-is.com/)

[prov-api](https://f1743-prov-api.dev.rrap-is.com/)

[prov-ui](https://f1743-prov.dev.rrap-is.com/)

[registry-api](https://f1743-registry-api.dev.rrap-is.com/)

[registry-ui](https://f1743-registry.dev.rrap-is.com/)

To tear down feature deployment: ./fb destroy 1743 non-rrap-deployment-licences
