### PR TITLE
feat: enable model run deletion

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -309,3 +309,5 @@ admin-tooling/environments.json
 
 # the config targets
 env.json
+
+.python-version

--- a/auth-api/main.py
+++ b/auth-api/main.py
@@ -18,6 +18,15 @@ import sentry_sdk
 from mangum import Mangum  # type: ignore
 import uvicorn  # type: ignore
 
+# Patch for HTTPException to improve string representation
+from fastapi import HTTPException
+
+def httpexception_str_patch(self: HTTPException) -> str:
+    return f"Status code: {self.status_code}, details: {self.detail}."
+
+# Apply the patch
+HTTPException.__str__ = httpexception_str_patch  # type: ignore
+
 # Setup app
 app = FastAPI()
 init_sentry(

--- a/data-store-api/main.py
+++ b/data-store-api/main.py
@@ -19,6 +19,14 @@ from routes.admin import admin
 from routes.check_access import checks
 from routes.release import release
 
+# Patch for HTTPException to improve string representation
+from fastapi import HTTPException
+
+def httpexception_str_patch(self: HTTPException) -> str:
+    return f"Status code: {self.status_code}, details: {self.detail}."
+
+# Apply the patch
+HTTPException.__str__ = httpexception_str_patch  # type: ignore
 
 # Setup app
 app = FastAPI()

--- a/id-service-api/main.py
+++ b/id-service-api/main.py
@@ -13,6 +13,15 @@ import time
 from ProvenaSharedFunctionality.SentryMonitoring import init_sentry
 import sentry_sdk
 
+# Patch for HTTPException to improve string representation
+from fastapi import HTTPException
+
+def httpexception_str_patch(self: HTTPException) -> str:
+    return f"Status code: {self.status_code}, details: {self.detail}."
+
+# Apply the patch
+HTTPException.__str__ = httpexception_str_patch  # type: ignore
+
 # Setup app
 app = FastAPI()
 init_sentry(

--- a/job-api/main.py
+++ b/job-api/main.py
@@ -18,6 +18,15 @@ from ProvenaInterfaces.AsyncJobAPI import JOBS_USER_PREFIX, JOBS_ADMIN_PREFIX
 from ProvenaSharedFunctionality.SentryMonitoring import init_sentry
 import sentry_sdk
 
+# Patch for HTTPException to improve string representation
+from fastapi import HTTPException
+
+def httpexception_str_patch(self: HTTPException) -> str:
+    return f"Status code: {self.status_code}, details: {self.detail}."
+
+# Apply the patch
+HTTPException.__str__ = httpexception_str_patch  # type: ignore
+
 # Setup app
 app = FastAPI()
 init_sentry(

--- a/prov-api/api-test/model_run_delete.http
+++ b/prov-api/api-test/model_run_delete.http
@@ -7,7 +7,7 @@ Content-Type: application/json
 Authorization: Bearer {{TOKEN}}
 
 {
-  "record_id": "10378.1/1983187"
+  "record_id": "real-handle-here"
 }
 
 ### Test with invalid/non-existent ID (should return 400)

--- a/prov-api/api-test/model_run_delete.http
+++ b/prov-api/api-test/model_run_delete.http
@@ -1,13 +1,25 @@
 @API_ENDPOINT = {{$dotenv API_ENDPOINT}}
 @TOKEN = {{$dotenv TOKEN}}
-
-### Test Model Run Delete Endpoint
+ 
+### Test Model Run Delete Endpoint (trial)
 POST {{API_ENDPOINT}}/model_run/delete
 Content-Type: application/json
 Authorization: Bearer {{TOKEN}}
 
 {
-  "record_id": "real-handle-here"
+  "record_id": "10378.1/1983186",
+  "trial_mode": true
+}
+
+
+### Test Model Run Delete Endpoint (apply)
+POST {{API_ENDPOINT}}/model_run/delete
+Content-Type: application/json
+Authorization: Bearer {{TOKEN}}
+
+{
+  "record_id": "real-handle-here",
+  "trial_mode": false
 }
 
 ### Test with invalid/non-existent ID (should return 400)

--- a/prov-api/api-test/model_run_delete.http
+++ b/prov-api/api-test/model_run_delete.http
@@ -1,0 +1,20 @@
+@API_ENDPOINT = {{$dotenv API_ENDPOINT}}
+@TOKEN = {{$dotenv TOKEN}}
+
+### Test Model Run Delete Endpoint
+POST {{API_ENDPOINT}}/model_run/delete
+Content-Type: application/json
+Authorization: Bearer {{TOKEN}}
+
+{
+  "record_id": "10378.1/1983187"
+}
+
+### Test with invalid/non-existent ID (should return 400)
+POST {{API_ENDPOINT}}/model_run/delete
+Content-Type: application/json
+Authorization: Bearer {{TOKEN}}
+
+{
+  "record_id": "invalid-id-12345"
+}

--- a/prov-api/docker-requirements.txt
+++ b/prov-api/docker-requirements.txt
@@ -6,6 +6,7 @@ python-multipart
 setuptools
 boto3
 jsonschema
+rdflib==7.1.4
 httpx==0.27.2
 mangum
 aws-secretsmanager-caching

--- a/prov-api/helpers/prov_connector.py
+++ b/prov-api/helpers/prov_connector.py
@@ -963,28 +963,28 @@ class DiffActionType(str, Enum):
     """
 
     # Add a new node to the graph
-    ADD_NEW_NODE = auto()
+    ADD_NEW_NODE = "ADD_NEW_NODE"
 
     # Completely remove a node from the graph
-    REMOVE_NODE = auto()
+    REMOVE_NODE = "REMOVE_NODE"
 
     # Add a brand new link to the graph
-    ADD_NEW_LINK = auto()
+    ADD_NEW_LINK = "ADD_NEW_LINK"
 
     # Remove a link completely from the graph
-    REMOVE_LINK = auto()
-
+    REMOVE_LINK = "REMOVE_LINK"
+    
     # Remove a record id on link from the CSV list of record ids
-    REMOVE_RECORD_ID_FROM_LINK = auto()
+    REMOVE_RECORD_ID_FROM_LINK = "REMOVE_RECORD_ID_FROM_LINK"
 
     # Remove a record id on node from the CSV list of record ids
-    REMOVE_RECORD_ID_FROM_NODE = auto()
+    REMOVE_RECORD_ID_FROM_NODE = "REMOVE_RECORD_ID_FROM_NODE"
 
     # Add record id on link to the CSV list of record ids
-    ADD_RECORD_ID_TO_LINK = auto()
+    ADD_RECORD_ID_TO_LINK = "ADD_RECORD_ID_TO_LINK"
 
     # Add record id on node to the CSV list of record ids
-    ADD_RECORD_ID_TO_NODE = auto()
+    ADD_RECORD_ID_TO_NODE = "ADD_RECORD_ID_TO_NODE"
 
 # ==============
 # ACTION CLASSES
@@ -1465,7 +1465,7 @@ class GraphDiffApplier:
         """
         # Diff the graphs
         diff_actions = diff_graphs(old_graph, new_graph)
-        # sort thea ctions
+        # sort the actions
         sorted_actions = self._sort_diff_actions(diff_actions)
         # apply all actions
 

--- a/prov-api/job_requirements/base.txt
+++ b/prov-api/job_requirements/base.txt
@@ -1,1 +1,2 @@
 typer
+rdflib==7.1.4

--- a/prov-api/main.py
+++ b/prov-api/main.py
@@ -14,6 +14,16 @@ from typing import Dict
 from ProvenaSharedFunctionality.SentryMonitoring import init_sentry
 import sentry_sdk
 
+# Patch for HTTPException to improve string representation
+from fastapi import HTTPException
+
+def httpexception_str_patch(self: HTTPException) -> str:
+    return f"Status code: {self.status_code}, details: {self.detail}."
+
+# Apply the patch
+HTTPException.__str__ = httpexception_str_patch  # type: ignore
+
+
 # Setup app
 app = FastAPI()
 init_sentry(

--- a/prov-api/requirements.txt
+++ b/prov-api/requirements.txt
@@ -5,6 +5,7 @@ python-jose
 setuptools
 boto3
 jsonschema
+rdflib==7.1.4
 httpx==0.27.2
 mangum
 aws-secretsmanager-caching

--- a/prov-api/routes/model_run/model_run.py
+++ b/prov-api/routes/model_run/model_run.py
@@ -24,7 +24,7 @@ async def register_model_run_complete(
     record: ModelRunRecord,
     roles: ProtectedRole = Depends(read_write_user_protected_role_dependency),
     config: Config = Depends(get_settings),
-    user_cipher : str = Depends(get_user_cipher)
+    user_cipher: str = Depends(get_user_cipher)
 ) -> RegisterModelRunResponse:
     """    register_model_run_complete
         Given the model run record object (schema/model) will:
@@ -110,7 +110,7 @@ async def register_batch(
     request: RegisterBatchModelRunRequest,
     roles: ProtectedRole = Depends(read_write_user_protected_role_dependency),
     config: Config = Depends(get_settings),
-    user_cipher : str = Depends(get_user_cipher)
+    user_cipher: str = Depends(get_user_cipher)
 ) -> RegisterBatchModelRunResponse:
     # TODO should we validate items first? No - validate at batch time?
     # Then produce job using Job API and return session ID
@@ -144,7 +144,7 @@ async def register_model_run_sync(
     # admin only for this endpoint
     roles: ProtectedRole = Depends(admin_user_protected_role_dependency),
     config: Config = Depends(get_settings),
-    user_cipher : str = Depends(get_user_cipher)
+    user_cipher: str = Depends(get_user_cipher)
 ) -> SyncRegisterModelRunResponse:
     # no proxy - user direct
     request_style = RequestStyle(
@@ -184,7 +184,7 @@ async def link_to_study(
     study_id: str,
     roles: ProtectedRole = Depends(read_write_user_protected_role_dependency),
     config: Config = Depends(get_settings),
-    user_cipher : str = Depends(get_user_cipher)
+    user_cipher: str = Depends(get_user_cipher)
 ) -> AddStudyLinkResponse:
 
     # validate model_run_id and study_id to be linked.
@@ -248,12 +248,12 @@ async def link_to_study(
     )
 
 
-@ router.post("/update", response_model=PostUpdateModelRunResponse, operation_id="update_model_run", include_in_schema=True)
+@router.post("/update", response_model=PostUpdateModelRunResponse, operation_id="update_model_run", include_in_schema=True)
 async def update_model_run(
     payload: PostUpdateModelRunInput,
     roles: ProtectedRole = Depends(read_write_user_protected_role_dependency),
     config: Config = Depends(get_settings),
-    user_cipher : str = Depends(get_user_cipher)
+    user_cipher: str = Depends(get_user_cipher)
 ) -> PostUpdateModelRunResponse:
     # no proxy - user direct
     request_style = RequestStyle(
@@ -286,46 +286,40 @@ async def update_model_run(
 
     return PostUpdateModelRunResponse(session_id=res)
 
-#
-#
-# class DeleteGraph(BaseModel):
-#    record_id: str
-#
-#
-# @router.post("/delete_graph", operation_id="delete_graph", include_in_schema=False)
-# async def delete_graph(
-#    delete: DeleteGraph,
-#    # admin only for this endpoint
-#    roles: ProtectedRole = Depends(admin_user_protected_role_dependency),
-#    config: Config = Depends(get_settings)
-# ) -> Any:
-#    # no proxy - user direct
-#    request_style = RequestStyle(
-#        service_account=None, user_direct=roles.user)
-#
-#    # dummy delete graph
-#    delete_dummy_graph = NodeGraph(record_id=delete.record_id, links=[])
-#
-#    print("Setting up neo4j client")
-#    neo4j_manager = Neo4jGraphManager(config=config)
-#    print("Done")
-#
-#    # Getting old graph
-#    print("Retrieving graph")
-#    old_graph = neo4j_manager.get_graph_by_record_id(delete.record_id)
-#    print("Done")
-#
-#    # get the graph diff
-#    print("Building diff and applying...")
-#    diff_generator = GraphDiffApplier(neo4j_manager=neo4j_manager)
-#    diff_generator.apply_diff(
-#        old_graph=old_graph, new_graph=delete_dummy_graph)
-#    print("Done")
-#
-#    # get the updated graph
-#    print("Retrieving updated graph")
-#    updated_graph = neo4j_manager.get_graph_by_record_id(delete.record_id)
-#    print("Done")
-#
-#    return {"old_graph": old_graph.to_json_pretty(), "updated": updated_graph.to_json_pretty()}
-#
+
+@router.post("/delete_graph", operation_id="delete_graph", include_in_schema=False)
+async def delete_graph(
+    delete: PostDeleteGraphRequest,
+    # admin only for this endpoint
+    roles: ProtectedRole = Depends(admin_user_protected_role_dependency),
+    config: Config = Depends(get_settings)
+) -> None:
+    # no proxy - user direct
+    request_style = RequestStyle(
+        service_account=None, user_direct=roles.user)
+
+    # dummy delete graph
+    delete_dummy_graph = NodeGraph(record_id=delete.record_id, links=[])
+
+    print("Setting up neo4j client")
+    neo4j_manager = Neo4jGraphManager(config=config)
+    print("Done")
+
+    # Getting old graph
+    print("Retrieving graph")
+    old_graph = neo4j_manager.get_graph_by_record_id(delete.record_id)
+    print("Done")
+
+    # get the graph diff
+    print("Building diff and applying...")
+    diff_generator = GraphDiffApplier(neo4j_manager=neo4j_manager)
+    diff_generator.apply_diff(
+        old_graph=old_graph, new_graph=delete_dummy_graph)
+    print("Done")
+
+    # get the updated graph
+    print("Retrieving updated graph")
+    updated_graph = neo4j_manager.get_graph_by_record_id(delete.record_id)
+    print("Done")
+
+    return None

--- a/prov-api/routes/model_run/model_run.py
+++ b/prov-api/routes/model_run/model_run.py
@@ -13,6 +13,7 @@ from ProvenaSharedFunctionality.Helpers.encryption_helpers import encrypt_user_i
 from helpers.job_api_helpers import submit_model_run_lodge_job, submit_batch_lodge_job, submit_model_run_lodge_only_job, submit_model_run_update_job
 from ProvenaInterfaces.AsyncJobModels import ProvLodgeModelRunPayload, ProvLodgeBatchSubmitPayload, ProvLodgeModelRunLodgeOnlyPayload, ProvLodgeUpdatePayload
 from config import get_settings, Config
+from helpers.prov_connector import NodeGraph, Neo4jGraphManager, GraphDiffApplier
 
 router = APIRouter()
 
@@ -298,7 +299,7 @@ async def delete_graph(
     request_style = RequestStyle(
         service_account=None, user_direct=roles.user)
 
-    # dummy delete graph
+    # dummy delete graph which is just an empty graph with the record id to delete
     delete_dummy_graph = NodeGraph(record_id=delete.record_id, links=[])
 
     print("Setting up neo4j client")
@@ -306,20 +307,15 @@ async def delete_graph(
     print("Done")
 
     # Getting old graph
-    print("Retrieving graph")
+    print("Retrieving existing graph")
     old_graph = neo4j_manager.get_graph_by_record_id(delete.record_id)
     print("Done")
 
     # get the graph diff
-    print("Building diff and applying...")
+    print("Building diff (empty) and applying...")
     diff_generator = GraphDiffApplier(neo4j_manager=neo4j_manager)
     diff_generator.apply_diff(
         old_graph=old_graph, new_graph=delete_dummy_graph)
-    print("Done")
-
-    # get the updated graph
-    print("Retrieving updated graph")
-    updated_graph = neo4j_manager.get_graph_by_record_id(delete.record_id)
     print("Done")
 
     return None

--- a/registry-api/docker-requirements.txt
+++ b/registry-api/docker-requirements.txt
@@ -10,8 +10,9 @@ mangum
 aws-secretsmanager-caching
 pydantic[email]==1.10.17
 python-dotenv
-shapely
-pyproj
+numpy==2.2.2
+shapely==2.0.7
+pyproj==3.6.1
 sentry-sdk[fastapi]
 mypy-boto3-kms
 

--- a/registry-api/lambda_dockerfile
+++ b/registry-api/lambda_dockerfile
@@ -1,12 +1,8 @@
 # Includes lambda runtime 
 FROM public.ecr.aws/lambda/python:3.11
 
-# Install git and PROJ dependencies for geospatial packages
-RUN yum -y install git \
-    proj-devel \
-    proj \
-    geos-devel \
-    && yum clean all
+# Install git
+RUN yum -y install git
 
 # Build arg input from deployment
 ARG github_token 

--- a/registry-api/lambda_dockerfile
+++ b/registry-api/lambda_dockerfile
@@ -1,8 +1,12 @@
 # Includes lambda runtime 
 FROM public.ecr.aws/lambda/python:3.11
 
-# Install git for pip install which requires git packages
-RUN yum -y install git
+# Install git and PROJ dependencies for geospatial packages
+RUN yum -y install git \
+    proj-devel \
+    proj \
+    geos-devel \
+    && yum clean all
 
 # Build arg input from deployment
 ARG github_token 
@@ -15,9 +19,7 @@ ENV BRANCH_NAME=$branch_name
 ENV REPO_STRING=$repo_string
 
 WORKDIR ${LAMBDA_TASK_ROOT}
-
 COPY . .
-
 RUN python3 -m ensurepip
 
 # add cache buster layer which can be injected with hash of extra dirs or other changed things

--- a/registry-api/main.py
+++ b/registry-api/main.py
@@ -21,6 +21,17 @@ from route_models import RouteConfig
 from ProvenaSharedFunctionality.SentryMonitoring import init_sentry
 import sentry_sdk
 
+
+# Patch for HTTPException to improve string representation
+from fastapi import HTTPException
+
+def httpexception_str_patch(self: HTTPException) -> str:
+    return f"Status code: {self.status_code}, details: {self.detail}."
+
+# Apply the patch
+HTTPException.__str__ = httpexception_str_patch  # type: ignore
+
+
 app = FastAPI()
 init_sentry(
     dsn=base_config.sentry_dsn if base_config.monitoring_enabled else None,

--- a/registry-api/requirements.txt
+++ b/registry-api/requirements.txt
@@ -11,8 +11,9 @@ aws-secretsmanager-caching
 types-requests
 pydantic[email]==1.10.17
 python-dotenv
-shapely
-pyproj
+numpy==2.2.2
+shapely==2.0.7
+pyproj==3.6.1
 sentry-sdk[fastapi]
 mypy-boto3-kms
 

--- a/search-api/main.py
+++ b/search-api/main.py
@@ -16,6 +16,15 @@ import json
 
 from typing import Dict
 
+# Patch for HTTPException to improve string representation
+from fastapi import HTTPException
+
+def httpexception_str_patch(self: HTTPException) -> str:
+    return f"Status code: {self.status_code}, details: {self.detail}."
+
+# Apply the patch
+HTTPException.__str__ = httpexception_str_patch  # type: ignore
+
 # Setup app
 app = FastAPI()
 init_sentry(

--- a/utilities/packages/python/provena-interfaces/ProvenaInterfaces/ProvenanceAPI.py
+++ b/utilities/packages/python/provena-interfaces/ProvenaInterfaces/ProvenanceAPI.py
@@ -85,3 +85,9 @@ class GenerateReportRequest(BaseModel):
 
 class PostDeleteGraphRequest(BaseModel):
     record_id: str
+    trial_mode: bool = False
+
+
+class PostDeleteGraphResponse(BaseModel):
+    # Diff list - each entry is a diff action with possible other metadata
+    diff: List[Dict[str, Any]]

--- a/utilities/packages/python/provena-interfaces/ProvenaInterfaces/ProvenanceAPI.py
+++ b/utilities/packages/python/provena-interfaces/ProvenaInterfaces/ProvenanceAPI.py
@@ -75,8 +75,13 @@ class PostUpdateModelRunInput(BaseModel):
 class PostUpdateModelRunResponse(BaseModel):
     session_id: str
 
+
 class GenerateReportRequest(BaseModel):
     id: str
     item_subtype: ItemSubType
     # Greater than or equal to 1 and less than equal to 3
     depth: int = Field(ge=1, le=3)
+
+
+class PostDeleteGraphRequest(BaseModel):
+    record_id: str


### PR DESCRIPTION
Adds model run deletion endpoint to the prov-api. 

This was already implemented, but this improves it and fixes some issues along the way. 

Did some basic http testing - considering this is admin only for now, and it needs to be combined with a client side registry API delete - I think its higher priority to get this change through than robustly test it. Will deploy to dev first and poke around as this will be a non-trivial prod redeployment due to the other lib version bumps etc.

Fixed

- version pins for some libs in registry API which were broken
- adds __str__ method patch to HTTPException in all APIs to reduce the 'Error: ' we've been seeing constantly
- adds the rdflib dependency which somehow was missed by pip!

Next steps are to

- deploy to dev 
- deploy provena interfaces
- test dev
- build client lib support
- publish client lib support
- build /scripts support


Feature branch name: **feat-1010-enable-model-run-delete**

URL Prefix: f1010

Pipeline links: [pipelines](https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines?region=ap-southeast-2&pipelines-meta=eyJmIjp7InRleHQiOiJmMTAxMCJ9LCJzIjp7InByb3BlcnR5IjoidXBkYXRlZCIsImRpcmVjdGlvbiI6LTF9LCJuIjoxMCwiaSI6MH0K)

Deployed components:

[landing-portal](https://f1010.dev.rrap-is.com/)

[job-api](https://f1010-job-api.dev.rrap-is.com/)

[data-store-api](https://f1010-data-api.dev.rrap-is.com/)

[data-store-ui](https://f1010-data.dev.rrap-is.com/)

[auth-api](https://f1010-auth-api.dev.rrap-is.com/)

[prov-api](https://f1010-prov-api.dev.rrap-is.com/)

[prov-ui](https://f1010-prov.dev.rrap-is.com/)

[registry-api](https://f1010-registry-api.dev.rrap-is.com/)

[registry-ui](https://f1010-registry.dev.rrap-is.com/)

To tear down feature deployment: ./fb destroy 1010 enable-model-run-delete