### PR TITLE
fix: normalize prov lineage graph payload (edges vs links)

### DIFF
--- a/utilities/packages/typescript/react-libs/src/hooks/useProvGraphData.tsx
+++ b/utilities/packages/typescript/react-libs/src/hooks/useProvGraphData.tsx
@@ -29,6 +29,45 @@ export interface NodeGraphData {
   links: GraphLinkData[];
 }
 
+/**
+ * Coerce lineage API graph payloads into NodeGraphData. NetworkX 3+ uses
+ * `edges` instead of `links` in node_link_data; some payloads use `from`/`to`
+ * for endpoints instead of `source`/`target`.
+ */
+export function normalizeLineageGraphPayload(raw: unknown): NodeGraphData {
+  if (!raw || typeof raw !== "object") {
+    return { nodes: [], links: [] };
+  }
+  const g = raw as Record<string, unknown>;
+  const nodes = Array.isArray(g.nodes) ? (g.nodes as GraphNodeData[]) : [];
+  const rawEdgeList = g.links ?? g.edges;
+  const edgeList = Array.isArray(rawEdgeList) ? rawEdgeList : [];
+
+  const endpointId = (v: unknown): string => {
+    if (v === null || v === undefined) {
+      return "";
+    }
+    if (typeof v === "object" && "id" in (v as object)) {
+      return String((v as { id: unknown }).id);
+    }
+    return String(v);
+  };
+
+  const links: GraphLinkData[] = edgeList.map((link) => {
+    const L = link as Record<string, unknown>;
+    const source = endpointId(L.source ?? L.from);
+    const target = endpointId(L.target ?? L.to);
+    const typeVal = L.type ?? L.label ?? "";
+    return {
+      source,
+      target,
+      type: String(typeVal),
+    };
+  });
+
+  return { nodes, links };
+}
+
 export interface GraphConfig {}
 
 const DEFAULT_CONFIG: GraphConfig = {};
@@ -316,10 +355,8 @@ export const useProvGraphData = (
         // This can potentially be a list of lineage responses - not just one
         const lineageResponse = result.data;
 
-        // Parse as graphs
-        const fallbackGraph = { nodes: [], links: [] } as NodeGraphData;
-        const newGraph = (lineageResponse.graph ??
-          fallbackGraph) as unknown as NodeGraphData;
+        // Parse as graphs (normalize edges vs links and endpoint field names)
+        const newGraph = normalizeLineageGraphPayload(lineageResponse.graph);
         cumulativeGraph = mergeGraphs(cumulativeGraph, newGraph);
       }
     }


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
# fix: normalize prov lineage graph payload (edges vs links)

## Ticket: RRAPIS-XXXX (graph links / B184)

## Checklist

-   [ ] If tests are required for this change, are they implemented?
-   [ ] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [ ] If migrations are required, is the process documented below?
-   [ ] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [ ] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [ ] If this change requires updates to the [Provena Python Client](https://github.com/provena/provena-python-client), is this accounted for?

## Description

The provenance exploration graph crashed with `TypeError: ... links is not iterable` after a successful lineage API response. The backend can return NetworkX `node_link_data` in a shape where edges are under `edges` (NetworkX 3+) instead of `links`, and endpoints may appear as `from`/`to` instead of `source`/`target`.

This change adds `normalizeLineageGraphPayload` in `useProvGraphData.tsx` to coerce any lineage `graph` payload into `NodeGraphData` with iterable `links` and string `source`/`target` fields before `mergeGraphs` runs.

## Migrations Required

None.

## Notes for reviewer

- Primary file: `utilities/packages/typescript/react-libs/src/hooks/useProvGraphData.tsx` (consumed by prov-ui via symlinked `react-libs`).

## Feature branch

N/A

<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-5cc672eb-a967-4ad2-ae3e-82a60dd27b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-5cc672eb-a967-4ad2-ae3e-82a60dd27b62"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

