### PR TITLE
fix: keycloak fargate wildfly private interface

### DIFF
--- a/infrastructure/provena/component_constructs/keycloak_infrastructure.py
+++ b/infrastructure/provena/component_constructs/keycloak_infrastructure.py
@@ -231,13 +231,14 @@ class KeycloakConstruct(Construct):
             "DB_DATABASE": "keycloak",
             "DB_USER": "keycloak",
             "PROXY_ADDRESS_FORWARDING": "true",
-            # WildFly resolves a logical "private" interface for mod_cluster/JGroups.
-            # In Fargate/container networks, NIC layout can change (e.g. platform
-            # updates), causing WFLYSRV0082 "failed to resolve interface private".
-            # Pin bind addresses explicitly (same idea as -Djboss.bind.address.* on docker run).
-            "JAVA_OPTS_APPEND": (
-                "-Djboss.bind.address.private=127.0.0.1 "
-                "-Djboss.bind.address=0.0.0.0"
+            # Keycloak entrypoint builds BIND_OPTS from hostname --all-ip-addresses unless
+            # BIND_OPTS is set; it passes those flags to standalone.sh after JAVA_OPTS, so
+            # JAVA_OPTS_APPEND cannot reliably override. Multiple IPs → last-wins bind props
+            # and WildFly can fail WFLYSRV0082 on interface private; we also patch
+            # standalone-ha.xml (Dockerfile) to use <nic name="lo"/> for private.
+            "BIND_OPTS": (
+                "-Djboss.bind.address=0.0.0.0 "
+                "-Djboss.bind.address.private=127.0.0.1"
             ),
             # Set debug log level for non production
             "KEYCLOAK_LOGLEVEL": "DEBUG"

--- a/infrastructure/provena/component_constructs/keycloak_infrastructure.py
+++ b/infrastructure/provena/component_constructs/keycloak_infrastructure.py
@@ -231,6 +231,14 @@ class KeycloakConstruct(Construct):
             "DB_DATABASE": "keycloak",
             "DB_USER": "keycloak",
             "PROXY_ADDRESS_FORWARDING": "true",
+            # WildFly resolves a logical "private" interface for mod_cluster/JGroups.
+            # In Fargate/container networks, NIC layout can change (e.g. platform
+            # updates), causing WFLYSRV0082 "failed to resolve interface private".
+            # Pin bind addresses explicitly (same idea as -Djboss.bind.address.* on docker run).
+            "JAVA_OPTS_APPEND": (
+                "-Djboss.bind.address.private=127.0.0.1 "
+                "-Djboss.bind.address=0.0.0.0"
+            ),
             # Set debug log level for non production
             "KEYCLOAK_LOGLEVEL": "DEBUG"
         }

--- a/infrastructure/provena/keycloak/Dockerfile
+++ b/infrastructure/provena/keycloak/Dockerfile
@@ -1,5 +1,12 @@
 FROM quay.io/keycloak/keycloak:16.0.0
 
+# Keycloak's docker-entrypoint.sh builds BIND_OPTS from `hostname --all-ip-addresses`,
+# repeating -Djboss.bind.address and -Djboss.bind.address.private for each IP (last wins).
+# On some Fargate/CNI setups that makes WildFly's inet-address for "private" ambiguous
+# or inconsistent (WFLYSRV0082). Loopback by NIC name is always a single match.
+RUN sed -i 's|<inet-address value="${jboss.bind.address.private:127.0.0.1}"/>|<nic name="lo"/>|' \
+    /opt/jboss/keycloak/standalone/configuration/standalone-ha.xml
+
 ARG KC_THEME_NAME
 
 # Include the modules in the plugin folder

--- a/infrastructure/provena/keycloak/NewDBDockerfile
+++ b/infrastructure/provena/keycloak/NewDBDockerfile
@@ -1,5 +1,9 @@
 FROM quay.io/keycloak/keycloak:16.0.0
 
+# See Dockerfile in this folder for rationale (WFLYSRV0082 private interface on Fargate).
+RUN sed -i 's|<inet-address value="${jboss.bind.address.private:127.0.0.1}"/>|<nic name="lo"/>|' \
+    /opt/jboss/keycloak/standalone/configuration/standalone-ha.xml
+
 # Include the modules in the plugin folder
 COPY ./modules/* /opt/jboss/keycloak/providers/
 


### PR DESCRIPTION
## Summary

Fixes Keycloak on ECS Fargate failing to boot cleanly with **WildFly `WFLYSRV0082: failed to resolve interface private`**, leaving the task in a **“started (with errors)”** state with dozens of dependent services down.

## Problem

- Logs showed **`org.wildfly.network.interface.private`** failing during boot, with **~54 failed services** and cascading dependency failures, even though deployment sometimes appeared to progress.
- This showed up **without application code changes**, consistent with **environment / platform networking** drift (e.g. Fargate roll-forward, dual-stack / extra addresses on the task, etc.).

## Root cause

1. **Keycloak 16’s `docker-entrypoint.sh`** builds **`BIND_OPTS`** from **`hostname --all-ip-addresses`**, appending **`-Djboss.bind.address`** and **`-Djboss.bind.address.private`** **for each** address. In the JVM, **repeated `-D` flags mean the last value wins**, so bind properties depend on **how many addresses** the task reports and in **what order**.
2. Those flags are passed into **`standalone.sh` as arguments**, which effectively apply **after** `JAVA_OPTS` (including **`JAVA_OPTS_APPEND`**). So **`JAVA_OPTS_APPEND` is not a reliable way to pin bind addresses** for this image.
3. WildFly’s **`standalone-ha.xml`** defines the logical **`private`** interface with **`inet-address`** tied to **`jboss.bind.address.private`**. When address/NIC resolution is **ambiguous** or inconsistent (multiple matches, or bad last-wins value from the loop above), **`NetworkInterfaceService`** fails with **WFLYSRV0082**.

## Solution

1. **ECS task env: `BIND_OPTS`** — Set explicitly so the entrypoint **skips** the `hostname` loop and uses stable values: **public** bind **`0.0.0.0`** (ALB), **private** **`127.0.0.1`** for the logical private interface in a single-node setup.
2. **Image build: patch `standalone-ha.xml`** — Replace the **`private`** interface’s **`inet-address`** stanza with **`<nic name="lo"/>`** so WildFly resolves **`private`** to **loopback by NIC name** (unambiguous), avoiding fragile **`inet-address`** matching across container interfaces.

Both **`Dockerfile`** and **`NewDBDockerfile`** apply the same XML change so snapshot and non-snapshot Keycloak builds stay aligned.

## Deployment / ops notes

- **Rebuild and redeploy the Keycloak container image**; CDK/env-only deploy is not enough for the **`standalone-ha.xml`** change.
- After rollout, confirm logs: **no** `failed to resolve interface private`, and a normal **started** line **without** “with errors” and without large numbers of failed services.

## References

- Keycloak image entrypoint: `BIND` / `BIND_OPTS` and `hostname --all-ip-addresses` behavior (`/opt/jboss/tools/docker-entrypoint.sh` in `quay.io/keycloak/keycloak:16.0.0`).
- WildFly **`standalone-ha.xml`**: `interface name="private"` and JGroups/mod_cluster socket bindings.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Changes Keycloak container runtime bind settings and patches WildFly configuration at image build time; misconfiguration could prevent Keycloak from starting or exposing unexpected interfaces.
> 
> **Overview**
> Prevents Keycloak 16 on ECS Fargate from booting into a *“started (with errors)”* state by making WildFly interface binding deterministic.
> 
> The ECS task now explicitly sets `BIND_OPTS` (public `0.0.0.0`, private `127.0.0.1`) to bypass Keycloak’s entrypoint auto-generated bind flags, and both Keycloak Dockerfiles patch `standalone-ha.xml` to resolve the `private` interface via loopback NIC (`<nic name="lo"/>`) instead of an `inet-address` property.
> 
> <sup>Reviewed by [Cursor Bugbot](https://cursor.com/bugbot) for commit 2dad455f2ee19f702d1bb3b87955a5defc7379d2. Bugbot is set up for automated code reviews on this repo. Configure [here](https://www.cursor.com/dashboard/bugbot).</sup>
<!-- /CURSOR_SUMMARY -->