### PR TITLE
RRAPIS-1961: Lineage Graph Fix

### DIFF
--- a/prov-api/helpers/prov_connector.py
+++ b/prov-api/helpers/prov_connector.py
@@ -299,7 +299,7 @@ def special_contributing_dataset_query(starting_id: str, depth: int, config: Con
     )
 
     # Return D3.js friendly serialisation
-    return networkx.node_link_data(graph)
+    return networkx.node_link_data(graph, edges="links")
 
 
 def special_effected_dataset_query(starting_id: str, depth: int, config: Config) -> Dict[str, Any]:
@@ -349,7 +349,7 @@ def special_effected_dataset_query(starting_id: str, depth: int, config: Config)
     )
 
     # Return D3.js friendly serialisation
-    return networkx.node_link_data(graph)
+    return networkx.node_link_data(graph, edges="links")
 
 
 def special_contributing_agent_query(starting_id: str, depth: int, config: Config) -> Dict[str, Any]:
@@ -399,7 +399,7 @@ def special_contributing_agent_query(starting_id: str, depth: int, config: Confi
     )
 
     # Return D3.js friendly serialisation
-    return networkx.node_link_data(graph)
+    return networkx.node_link_data(graph, edges="links")
 
 
 def special_effected_agent_query(starting_id: str, depth: int, config: Config) -> Dict[str, Any]:
@@ -449,7 +449,7 @@ def special_effected_agent_query(starting_id: str, depth: int, config: Config) -
     )
 
     # Return D3.js friendly serialisation
-    return networkx.node_link_data(graph)
+    return networkx.node_link_data(graph, edges="links")
 
 
 def upstream_query(starting_id: str, depth: int, config: Config) -> Dict[str, Any]:
@@ -521,7 +521,7 @@ def upstream_query(starting_id: str, depth: int, config: Config) -> Dict[str, An
     )
 
     # Return D3.js friendly serialisation
-    return networkx.node_link_data(graph)
+    return networkx.node_link_data(graph, edges="links")
 
 
 def downstream_query(starting_id: str, depth: int, config: Config) -> Dict[str, Any]:
@@ -593,7 +593,7 @@ def downstream_query(starting_id: str, depth: int, config: Config) -> Dict[str, 
     )
 
     # Return D3.js friendly serialisation
-    return networkx.node_link_data(graph)
+    return networkx.node_link_data(graph, edges="links")
 
 
 class NodeLinkProps(BaseModel):


### PR DESCRIPTION
# (fix): Fix broken lineage graph

## Ticket: RRAPIS-1961

## Checklist

-   [ ] If tests are required for this change, are they implemented?
-   [ ] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [ ] If migrations are required, is the process documented below?
-   [ ] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [ ] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [ ] If this change requires updates to the [Provena Python Client](https://github.com/provena/provena-python-client), is this accounted for?

## Description

The `networkx` library was recently bumped up a version, which has introduced a breaking change to the lineage graph feature of the `prov-ui`, with the default key for links in the serialised graph being changed from `"links"` to `"edges"`. This PR addresses this issue by making use of the override parameters available on the function call to ensure that the resulting JSON object uses the `"links"` key again. 

## Feature branch

Feature branch name: **feat-1961-fix-broken-lineage-graph**

URL Prefix: f1961

Pipeline links: [pipelines](https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines?region=ap-southeast-2&pipelines-meta=eyJmIjp7InRleHQiOiJmMTk2MSJ9LCJzIjp7InByb3BlcnR5IjoidXBkYXRlZCIsImRpcmVjdGlvbiI6LTF9LCJuIjoxMCwiaSI6MH0K)

Deployed components:

[landing-portal](https://f1961.dev.rrap-is.com/)

[job-api](https://f1961-job-api.dev.rrap-is.com/)

[data-store-api](https://f1961-data-api.dev.rrap-is.com/)

[data-store-ui](https://f1961-data.dev.rrap-is.com/)

[auth-api](https://f1961-auth-api.dev.rrap-is.com/)

[prov-api](https://f1961-prov-api.dev.rrap-is.com/)

[prov-ui](https://f1961-prov.dev.rrap-is.com/)

[registry-api](https://f1961-registry-api.dev.rrap-is.com/)

[registry-ui](https://f1961-registry.dev.rrap-is.com/)

To tear down feature deployment: ./fb destroy 1961 fix-broken-lineage-graph
