### PR TITLE
RRAPIS-1962: Add report generation job retries for job API cold starts

### DIFF
--- a/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
+++ b/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
@@ -15,7 +15,7 @@ import {
     SelectChangeEvent
 } from "@mui/material";
 
-import { useState, useEffect, useRef } from "react";
+import { useState } from "react";
 import { useGenerateReport } from "./useGenerateReport";
 import { useJobMonitor } from "./useJobMonitor";
 import { ItemSubType } from "../provena-interfaces/RegistryModels";
@@ -29,55 +29,18 @@ export interface GenerateReportProps {
 // A literal list with set depth values.
 const DEPTH_LIST = [1, 2, 3]
 
-// Auto-retry configuration for cold-start failures
-const MAX_RETRIES = 3;
-const RETRY_DELAY_MS = 5000;
-
 export const useGenerateReportDialog = (props: GenerateReportProps) => {
 
     const [popUpOpen, setPopupOpen] = useState<boolean>(false);
     const [depth, setDepth] = useState<number>(DEPTH_LIST[0]);
     const [sessionId, setSessionId] = useState<string | undefined>(undefined);
     const [reportUrl, setReportUrl] = useState<string | undefined>(undefined);
-    const [retryCount, setRetryCount] = useState<number>(0);
-    const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
-
     // Call the react-query defined. 
     const { mutate, dataReady } = useGenerateReport({
         id: props.id,
         itemSubType: props.itemSubType,
         depth: depth
     })
-
-    // Ref always pointing at the latest mutate object so retry timeouts avoid stale closures.
-    const mutateRef = useRef(mutate);
-
-    // Keep mutateRef current so the retry timeout always calls the latest mutate function.
-    useEffect(() => {
-        mutateRef.current = mutate;
-    });
-
-    // When the mutation errors, automatically retry up to MAX_RETRIES times.
-    useEffect(() => {
-        if (mutate?.isError && retryCount < MAX_RETRIES) {
-            const timeoutId = setTimeout(() => {
-                setRetryCount((prev: number) => prev + 1);
-                mutateRef.current?.mutate(undefined, {
-                    onSuccess: (res: any) => {
-                        const sid = res?.session_id ?? res?.sessionId ?? undefined;
-                        if (sid) {
-                            setSessionId(sid);
-                        }
-                    }
-                });
-            }, RETRY_DELAY_MS);
-            retryTimeoutRef.current = timeoutId;
-            return () => {
-                clearTimeout(timeoutId);
-                retryTimeoutRef.current = null;
-            };
-        }
-    }, [mutate?.isError, retryCount]);
 
     // Helper functions to open and close the popup. 
     const openDialog = () => {
@@ -90,11 +53,6 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
         setPopupOpen(false);
         setSessionId(undefined);
         setReportUrl(undefined);
-        setRetryCount(0);
-        if (retryTimeoutRef.current) {
-            clearTimeout(retryTimeoutRef.current);
-            retryTimeoutRef.current = null;
-        }
         if (dataReady) {
             // reset mutation
             mutate?.reset()
@@ -108,12 +66,6 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
     const onSubmit = () => {
         // Validate that a depth has been chosen.
         if (depth !== null && dataReady) {
-            // Cancel any pending auto-retry before a fresh manual submission
-            if (retryTimeoutRef.current) {
-                clearTimeout(retryTimeoutRef.current);
-                retryTimeoutRef.current = null;
-            }
-            setRetryCount(0);
             // Proceed to submit... store session id on success so we can monitor
             mutate?.mutate(undefined, {
                 onSuccess: (res: any) => {
@@ -132,7 +84,7 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
     const monitor = useJobMonitor({
         sessionId: sessionId,
         showIO: true,
-        refetchOnError: false,
+        refetchOnError: true,
         adminMode: false,
         onJobSuccess: (entry: any) => {
             const url = entry?.result?.report_url ?? entry?.result?.reportUrl;
@@ -148,16 +100,7 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
             <DialogContent>
                 <Stack spacing={2} gap={2} direction="column">
 
-                    {mutate?.isError && retryCount < MAX_RETRIES && (
-                        <Alert severity="warning" variant="outlined">
-                            <AlertTitle>Retrying automatically</AlertTitle>
-                            <Typography variant="subtitle1">
-                                The report service may be starting up. Retrying automatically (attempt {retryCount + 1} of {MAX_RETRIES})...
-                            </Typography>
-                        </Alert>
-                    )}
-
-                    {mutate?.isError && retryCount >= MAX_RETRIES && (
+                    {mutate?.isError && (
                         <Alert severity="error" variant="outlined">
                             <AlertTitle>An error occurred</AlertTitle>
                             <Typography variant="subtitle1">

--- a/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
+++ b/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
@@ -49,12 +49,20 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
         depth: depth
     })
 
+    // Ref always pointing at the latest mutate object so retry timeouts avoid stale closures.
+    const mutateRef = useRef(mutate);
+
+    // Keep mutateRef current so the retry timeout always calls the latest mutate function.
+    useEffect(() => {
+        mutateRef.current = mutate;
+    });
+
     // When the mutation errors, automatically retry up to MAX_RETRIES times.
     useEffect(() => {
         if (mutate?.isError && retryCount < MAX_RETRIES) {
             const timeoutId = setTimeout(() => {
                 setRetryCount((prev: number) => prev + 1);
-                mutate?.mutate(undefined, {
+                mutateRef.current?.mutate(undefined, {
                     onSuccess: (res: any) => {
                         const sid = res?.session_id ?? res?.sessionId ?? undefined;
                         if (sid) {

--- a/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
+++ b/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
@@ -114,7 +114,17 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
 
                     {/* If we have a session id, render the job monitor view */}
                     {sessionId ? (
-                        <div>{monitor.render()}</div>
+                        <div>
+                            {monitor.isRetrying && (
+                                <Alert severity="info" variant="outlined" sx={{ mb: 1 }}>
+                                    <AlertTitle>Starting up</AlertTitle>
+                                    <Typography variant="subtitle1">
+                                        The job service is starting up. Your report will begin shortly...
+                                    </Typography>
+                                </Alert>
+                            )}
+                            {monitor.render()}
+                        </div>
                     ) : (
                         <>
                             <DialogContentText>

--- a/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
+++ b/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
@@ -2,6 +2,7 @@ import {
     Alert,
     AlertTitle,
     Button,
+    CircularProgress,
     Dialog,
     DialogActions,
     DialogContent,
@@ -78,8 +79,8 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
         }
     }
 
-    // Submit button is disabled if depth is not picked.
-    const submitDisabled = depth === null
+    // Submit button is disabled if depth is not picked or mutation is in flight.
+    const submitDisabled = depth === null || !!mutate?.isLoading
 
     const monitor = useJobMonitor({
         sessionId: sessionId,
@@ -118,12 +119,15 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
                             {monitor.isRetrying && (
                                 <Alert severity="info" variant="outlined" sx={{ mb: 1 }}>
                                     <AlertTitle>Starting up</AlertTitle>
-                                    <Typography variant="subtitle1">
-                                        The job service is starting up. Your report will begin shortly...
-                                    </Typography>
+                                    <Stack direction="row" spacing={2} alignItems="center">
+                                        <Typography variant="subtitle1">
+                                            The job service is starting up. Your report will begin shortly...
+                                        </Typography>
+                                        <CircularProgress size={20} />
+                                    </Stack>
                                 </Alert>
                             )}
-                            {monitor.render()}
+                            {!monitor.isRetrying && monitor.render()}
                         </div>
                     ) : (
                         <>

--- a/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
+++ b/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
@@ -15,7 +15,7 @@ import {
     SelectChangeEvent
 } from "@mui/material";
 
-import { useState } from "react";
+import { useState, useEffect, useRef } from "react";
 import { useGenerateReport } from "./useGenerateReport";
 import { useJobMonitor } from "./useJobMonitor";
 import { ItemSubType } from "../provena-interfaces/RegistryModels";
@@ -29,12 +29,18 @@ export interface GenerateReportProps {
 // A literal list with set depth values.
 const DEPTH_LIST = [1, 2, 3]
 
+// Auto-retry configuration for cold-start failures
+const MAX_RETRIES = 3;
+const RETRY_DELAY_MS = 5000;
+
 export const useGenerateReportDialog = (props: GenerateReportProps) => {
 
     const [popUpOpen, setPopupOpen] = useState<boolean>(false);
     const [depth, setDepth] = useState<number>(DEPTH_LIST[0]);
     const [sessionId, setSessionId] = useState<string | undefined>(undefined);
     const [reportUrl, setReportUrl] = useState<string | undefined>(undefined);
+    const [retryCount, setRetryCount] = useState<number>(0);
+    const retryTimeoutRef = useRef<ReturnType<typeof setTimeout> | null>(null);
 
     // Call the react-query defined. 
     const { mutate, dataReady } = useGenerateReport({
@@ -42,6 +48,28 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
         itemSubType: props.itemSubType,
         depth: depth
     })
+
+    // When the mutation errors, automatically retry up to MAX_RETRIES times.
+    useEffect(() => {
+        if (mutate?.isError && retryCount < MAX_RETRIES) {
+            const timeoutId = setTimeout(() => {
+                setRetryCount((prev: number) => prev + 1);
+                mutate?.mutate(undefined, {
+                    onSuccess: (res: any) => {
+                        const sid = res?.session_id ?? res?.sessionId ?? undefined;
+                        if (sid) {
+                            setSessionId(sid);
+                        }
+                    }
+                });
+            }, RETRY_DELAY_MS);
+            retryTimeoutRef.current = timeoutId;
+            return () => {
+                clearTimeout(timeoutId);
+                retryTimeoutRef.current = null;
+            };
+        }
+    }, [mutate?.isError, retryCount]);
 
     // Helper functions to open and close the popup. 
     const openDialog = () => {
@@ -54,6 +82,11 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
         setPopupOpen(false);
         setSessionId(undefined);
         setReportUrl(undefined);
+        setRetryCount(0);
+        if (retryTimeoutRef.current) {
+            clearTimeout(retryTimeoutRef.current);
+            retryTimeoutRef.current = null;
+        }
         if (dataReady) {
             // reset mutation
             mutate?.reset()
@@ -67,6 +100,12 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
     const onSubmit = () => {
         // Validate that a depth has been chosen.
         if (depth !== null && dataReady) {
+            // Cancel any pending auto-retry before a fresh manual submission
+            if (retryTimeoutRef.current) {
+                clearTimeout(retryTimeoutRef.current);
+                retryTimeoutRef.current = null;
+            }
+            setRetryCount(0);
             // Proceed to submit... store session id on success so we can monitor
             mutate?.mutate(undefined, {
                 onSuccess: (res: any) => {
@@ -101,7 +140,16 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
             <DialogContent>
                 <Stack spacing={2} gap={2} direction="column">
 
-                    {mutate?.isError && (
+                    {mutate?.isError && retryCount < MAX_RETRIES && (
+                        <Alert severity="warning" variant="outlined">
+                            <AlertTitle>Retrying automatically</AlertTitle>
+                            <Typography variant="subtitle1">
+                                The report service may be starting up. Retrying automatically (attempt {retryCount + 1} of {MAX_RETRIES})...
+                            </Typography>
+                        </Alert>
+                    )}
+
+                    {mutate?.isError && retryCount >= MAX_RETRIES && (
                         <Alert severity="error" variant="outlined">
                             <AlertTitle>An error occurred</AlertTitle>
                             <Typography variant="subtitle1">

--- a/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
+++ b/utilities/packages/typescript/react-libs/src/hooks/useGenerateReportDialog.tsx
@@ -117,14 +117,13 @@ export const useGenerateReportDialog = (props: GenerateReportProps) => {
                     {sessionId ? (
                         <div>
                             {monitor.isRetrying && (
-                                <Alert severity="info" variant="outlined" sx={{ mb: 1 }}>
+                                <Alert severity="info" variant="outlined" sx={{ mb: 1 }}
+                                    icon={<CircularProgress size={20} />}
+                                >
                                     <AlertTitle>Starting up</AlertTitle>
-                                    <Stack direction="row" spacing={2} alignItems="center">
-                                        <Typography variant="subtitle1">
-                                            The job service is starting up. Your report will begin shortly...
-                                        </Typography>
-                                        <CircularProgress size={20} />
-                                    </Stack>
+                                    <Typography variant="subtitle1">
+                                        The job service is starting up. Your report will begin shortly...
+                                    </Typography>
                                 </Alert>
                             )}
                             {!monitor.isRetrying && monitor.render()}

--- a/utilities/packages/typescript/react-libs/src/hooks/useJobMonitor.tsx
+++ b/utilities/packages/typescript/react-libs/src/hooks/useJobMonitor.tsx
@@ -198,6 +198,8 @@ export interface UseJobMonitorOutput {
   // The entry if it is available
   entry: JobStatusTable | undefined;
   render: () => JSX.Element | null;
+  // True when the monitor has errored on a fetch but is still actively retrying
+  isRetrying: boolean;
 }
 export const useJobMonitor = (
   props: UseJobMonitorProps,
@@ -277,5 +279,6 @@ export const useJobMonitor = (
   return {
     entry: monitor.data,
     render,
+    isRetrying: monitor.error && monitor.isAutoRefetching,
   };
 };


### PR DESCRIPTION
# (fix): Add report generation job retries for job API cold starts

## Ticket: RRAPIS-1962

## Checklist

-   [ ] If tests are required for this change, are they implemented?
-   [ ] Are user documentation changes required, if so, is there a task to track it and/or is it completed?
-   [ ] If migrations are required, is the process documented below?
-   [ ] If developer/system documentation updates are required, is there a task to track it and/or is it completed?
-   [ ] At least one developer has reviewed this change (unless PR is being used to mark a commit point without need for review)?
-   [ ] If this change requires updates to the [Provena Python Client](https://github.com/provena/provena-python-client), is this accounted for?

## Description

Currently a failure occurs if the async job API service is starting from a cold state when a report generation request is sent via the new dialog, requiring the user to reopen the dialog completely. This PR makes use of existing options on the job monitor hook to allow for the continual re-fetching of job information from the API if a failure occurs. An additional output has been added to the hook to allow for clearer communication that automatic re-fetching is occurring.

## Notes for reviewer

Testing this can be tricky as the failure only occurs for the first request being made. The best way I have found to replicate the issue is to wait 5-10mins with no interaction, to allow the job API to fall back into a "cold" state. 

## Feature branch

Feature branch name: **feat-1962-fix-report-generation-dialog-failures**

URL Prefix: f1962

Pipeline links: [pipelines](https://ap-southeast-2.console.aws.amazon.com/codesuite/codepipeline/pipelines?region=ap-southeast-2&pipelines-meta=eyJmIjp7InRleHQiOiJmMTk2MiJ9LCJzIjp7InByb3BlcnR5IjoidXBkYXRlZCIsImRpcmVjdGlvbiI6LTF9LCJuIjoxMCwiaSI6MH0K)

Deployed components:

[landing-portal](https://f1962.dev.rrap-is.com/)

[job-api](https://f1962-job-api.dev.rrap-is.com/)

[data-store-api](https://f1962-data-api.dev.rrap-is.com/)

[data-store-ui](https://f1962-data.dev.rrap-is.com/)

[auth-api](https://f1962-auth-api.dev.rrap-is.com/)

[prov-api](https://f1962-prov-api.dev.rrap-is.com/)

[prov-ui](https://f1962-prov.dev.rrap-is.com/)

[registry-api](https://f1962-registry-api.dev.rrap-is.com/)

[registry-ui](https://f1962-registry.dev.rrap-is.com/)

To tear down feature deployment: ./fb destroy 1962 fix-report-generation-dialog-failures
